### PR TITLE
test: busted harness + extract resolveElasticCollision to modules/physics

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -129,16 +129,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Lua and LuaRocks
+      - name: Install Lua 5.4 and LuaRocks
+        # Ubuntu's `luarocks` package pulls in lua5.1 as a dependency, which
+        # then wins the /usr/bin/lua alternative. Our helper uses string.pack
+        # (Lua 5.3+), so we pin the interpreter back to 5.4.
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y lua5.4 liblua5.4-dev luarocks
+          sudo update-alternatives --set lua-interpreter /usr/bin/lua5.4
 
-      - name: Install busted
-        run: sudo luarocks install busted
+      - name: Install busted (against Lua 5.4)
+        run: sudo luarocks --lua-version=5.4 --lua-dir=/usr install busted
 
       - name: Run busted specs
         run: |
-          echo "▶ Running busted specs from spec/…"
+          echo "▶ Running busted specs from spec/ ($(lua -v 2>&1))…"
           busted --verbose spec/
           echo "✅ Unit tests passed"

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,9 +3,10 @@
 # Runs on every Pull Request targeting the `main` branch.
 #
 # Jobs:
-#   1. lint    — static analysis with luacheck
-#   2. syntax  — Lua syntax validation with luac
-#   3. package — verifies the game can be packaged into a .love file
+#   1. lint       — static analysis with luacheck
+#   2. syntax     — Lua syntax validation with luac
+#   3. package    — verifies the game can be packaged into a .love file
+#   4. unit-tests — busted specs for pure, non-LÖVE modules (net, physics)
 # =============================================================================
 
 name: PR Checks
@@ -116,3 +117,28 @@ jobs:
           name: SpaceWarrior-pr-${{ github.event.pull_request.number }}.love
           path: SpaceWarrior.love
           retention-days: 7
+
+  # ---------------------------------------------------------------------------
+  # 4. Unit Tests — busted specs for pure modules
+  # ---------------------------------------------------------------------------
+  unit-tests:
+    name: "Unit Tests — busted"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Lua and LuaRocks
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y lua5.4 liblua5.4-dev luarocks
+
+      - name: Install busted
+        run: sudo luarocks install busted
+
+      - name: Run busted specs
+        run: |
+          echo "▶ Running busted specs from spec/…"
+          busted --verbose spec/
+          echo "✅ Unit tests passed"

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -24,8 +24,13 @@ globals = {
     -- Dynamic key bindings (set in main.lua, mutated by SettingsState)
     "KEY_BINDINGS",
 
+    -- LAN networking state (set in main.lua, mutated by LobbyState/PlayState)
+    "NET",
+
     -- States
     "SettingsState",
+    "LobbyState",
+    "NetClientState",
 
     -- Physics world (set in PlayState:init, shared globally)
     "world",

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -93,3 +93,12 @@ ignore = {
 -- ── Style settings ────────────────────────────────────────────────────────────
 -- Line-length is not enforced: LÖVE draw calls are naturally verbose.
 max_line_length = false
+
+-- ── Per-path overrides ───────────────────────────────────────────────────────
+-- spec/ runs under busted (plain Lua 5.4, no LÖVE).  Pull in the `busted`
+-- standard-globals list (describe/it/assert/before_each/…) and allow spec
+-- helpers to define the `love` global as a test stub.
+files["spec"] = {
+    std = "+busted",
+    globals = { "love" },
+}

--- a/main.lua
+++ b/main.lua
@@ -93,10 +93,21 @@ function love.resize(w, h)
 end
 
 function love.keypressed(key)
-    gStateMachine.current:keypressed(key)
-    if key == "escape" then
-      love.event.quit()
+    -- F11 toggles fullscreen at any time
+    if key == 'f11' then
+        love.window.setFullscreen(not love.window.getFullscreen())
+        return
     end
+
+    -- ESC while fullscreen: exit fullscreen first, don't navigate anywhere
+    if key == 'escape' and love.window.getFullscreen() then
+        love.window.setFullscreen(false)
+        return
+    end
+
+    -- Route to the current state (each state handles ESC as "go back to previous screen")
+    -- The title screen is the only place that allows quitting (press Q)
+    gStateMachine.current:keypressed(key)
 end
 
 -- Route textinput to the current state (used by LobbyState for IP entry)

--- a/main.lua
+++ b/main.lua
@@ -16,6 +16,15 @@ KEY_BINDINGS = {
     [4] = { rotate = 'z',    shoot = 'x',  usepower = 'c'     },
 }
 
+-- Network state (set by LobbyState before entering play/netclient)
+NET = {
+    mode    = nil,      -- 'host' | 'client' | nil  (nil = local play)
+    localId = 1,        -- which player slot is on this machine
+    host    = nil,      -- enet host object
+    peer    = nil,      -- enet peer to communicate with
+    port    = 22122,
+}
+
 push = require 'push'
 Class = require 'Class'
 require 'StateMachine'
@@ -27,6 +36,8 @@ require 'states.ScoreState'
 require 'states.harsh_scoreState'
 require 'states.RuleBook'
 require 'states.SettingsState'
+require 'states.LobbyState'
+require 'states.NetClientState'
 wf = require 'libraries.windfield.windfield'
 --Anima = require("libraries/anim8/anim8")
 
@@ -40,13 +51,15 @@ function love.load()
     })
 
     gStateMachine = StateMachine{
-        ['title'] = function () return TitleState() end,
-        ['play'] = function () return PlayState() end,
-        ['end'] = function () return EndState() end,
-        ['score'] = function () return ScoreState() end,
-        ['newScore'] = function () return NewScoreState() end,
-        ['intro']    = function () return RuleBook() end,
-        ['settings'] = function () return SettingsState() end
+        ['title']     = function () return TitleState() end,
+        ['play']      = function () return PlayState() end,
+        ['end']       = function () return EndState() end,
+        ['score']     = function () return ScoreState() end,
+        ['newScore']  = function () return NewScoreState() end,
+        ['intro']     = function () return RuleBook() end,
+        ['settings']  = function () return SettingsState() end,
+        ['lobby']     = function () return LobbyState() end,
+        ['netclient'] = function () return NetClientState() end,
     }
 
     gStateMachine:change('title')
@@ -83,6 +96,13 @@ function love.keypressed(key)
     gStateMachine.current:keypressed(key)
     if key == "escape" then
       love.event.quit()
+    end
+end
+
+-- Route textinput to the current state (used by LobbyState for IP entry)
+function love.textinput(t)
+    if gStateMachine.current.textinput then
+        gStateMachine.current:textinput(t)
     end
 end
 

--- a/modules/Player.lua
+++ b/modules/Player.lua
@@ -18,8 +18,9 @@ function Player:init(id, x, y, radius)
     self.collider:setCollisionClass('player'..id)
     self.speed     = 350  -- current speed (reduced by collisions, recovers over time)
     self.basespeed = 350  -- maximum cruise speed
-    self.isLocal   = false   -- set true by PlayState for the player on this machine
-    self.controls  = {}      -- keybindings set by PlayState: { rotate, shoot, usepower }
+    self.isLocal      = false   -- set true by PlayState for the player on this machine
+    self.controls     = {}      -- keybindings set by PlayState: { rotate, shoot, usepower }
+    self.networkInput = { rotate=false }  -- driven by host when isLocal=false (LAN mode)
     self.coverbullettimer    = 2
     self.totalbullets        = 3
     self.bulletrecoverytimer = 0
@@ -37,14 +38,18 @@ function Player:update(dt)
             self.setrotation = (self.setrotation == 0) and 1 or 0
         end
 
-        -- Rotation input: only for the local player, using their configured key
+        -- Rotation input: local player uses keyboard; remote player uses networkInput
+        local doRotate = false
         if self.isLocal and self.controls.rotate then
-            if love.keyboard.isDown(self.controls.rotate) then
-                if self.setrotation == 0 then
-                    self.angle = self.angle - 4 * dt
-                else
-                    self.angle = self.angle + 4 * dt
-                end
+            doRotate = love.keyboard.isDown(self.controls.rotate)
+        elseif not self.isLocal and self.networkInput then
+            doRotate = self.networkInput.rotate == true
+        end
+        if doRotate then
+            if self.setrotation == 0 then
+                self.angle = self.angle - 4 * dt
+            else
+                self.angle = self.angle + 4 * dt
             end
         end
         self.bulletangle = self.bulletangle + 4 * dt

--- a/modules/net.lua
+++ b/modules/net.lua
@@ -38,8 +38,13 @@ function net.encodeStart()
     return love.data.pack("string", "B", net.MSG_START)
 end
 
-function net.encodeGameOver(winnerId)
-    return love.data.pack("string", "BB", net.MSG_GAMEOVER, winnerId or 0)
+-- winnerId: 1-based player index (0 = draw)
+-- p1score/p2score: current round-win counts so the client can show the same score screen
+function net.encodeGameOver(winnerId, p1score, p2score)
+    return love.data.pack("string", "BBBB",
+        net.MSG_GAMEOVER, winnerId or 0,
+        math.min(p1score or 0, 255),
+        math.min(p2score or 0, 255))
 end
 
 -- rotate / shoot / usepower: booleans
@@ -152,9 +157,9 @@ function net.decode(raw)
         return { type=net.MSG_START }
 
     elseif msgType == net.MSG_GAMEOVER then
-        if #raw < 2 then return nil end
-        local _, wi = love.data.unpack("BB", raw, 1)
-        return { type=net.MSG_GAMEOVER, winnerId=wi }
+        if #raw < 4 then return nil end
+        local _, wi, s1, s2 = love.data.unpack("BBBB", raw, 1)
+        return { type=net.MSG_GAMEOVER, winnerId=wi, p1score=s1, p2score=s2 }
     end
 
     return nil

--- a/modules/net.lua
+++ b/modules/net.lua
@@ -1,0 +1,163 @@
+-- modules/net.lua  ─ LAN Multiplayer networking utilities (Phase 2)
+-- Architecture: authoritative host runs all physics; client is a thin renderer.
+-- Protocol: enet (reliable UDP, bundled with LÖVE 11.x).
+
+local net = {}
+
+local enet_ok, enet = pcall(require, "enet")
+if not enet_ok then enet = nil end
+net.enet = enet
+
+-- ── Message type constants ────────────────────────────────────────────────────
+net.MSG_INPUT    = 1   -- client → host : rotate(B), shoot(B), usepower(B)
+net.MSG_STATE    = 2   -- host → client : full game snapshot
+net.MSG_START    = 3   -- host → client : "game is starting now"
+net.MSG_GAMEOVER = 4   -- host → client : winner announced
+
+net.PORT      = 22122
+net.TICK_RATE = 1 / 20   -- host broadcasts state 20 times per second
+
+-- ── Helpers ──────────────────────────────────────────────────────────────────
+-- Returns the LAN IP of this machine using the UDP-routing trick (no data sent).
+function net.getLocalIP()
+    local ok, socket = pcall(require, "socket")
+    if ok and socket then
+        local s = socket.udp()
+        if s then
+            s:connect("8.8.8.8", 1)
+            local ip = s:getsockname()
+            s:close()
+            if ip and ip ~= "0.0.0.0" then return ip end
+        end
+    end
+    return "see System Preferences › Network"
+end
+
+-- ── Simple encode helpers ─────────────────────────────────────────────────────
+function net.encodeStart()
+    return love.data.pack("string", "B", net.MSG_START)
+end
+
+function net.encodeGameOver(winnerId)
+    return love.data.pack("string", "BB", net.MSG_GAMEOVER, winnerId or 0)
+end
+
+-- rotate / shoot / usepower: booleans
+function net.encodeInput(rotate, shoot, usepower)
+    return love.data.pack("string", "BBBB",
+        net.MSG_INPUT,
+        rotate   and 1 or 0,
+        shoot    and 1 or 0,
+        usepower and 1 or 0)
+end
+
+-- ── Full state encoder ────────────────────────────────────────────────────────
+-- players      = PlayState.players  (array of Player objects)
+-- allBullets   = PlayState.allBullets
+-- Powersuplier = PlayState.Powersuplier
+-- pendingpower = PlayState.pendingpower  (table indexed by player id)
+-- gameOver, winnerId : end-of-round flags
+function net.encodeState(players, allBullets, Powersuplier, pendingpower, gameOver, winnerId)
+    local data = love.data.pack("string", "BB", net.MSG_STATE, #players)
+
+    for i, p in ipairs(players) do
+        local alive = (p.collider and p.collider.body) and 1 or 0
+        local x     = alive == 1 and p.collider:getX() or 0
+        local y     = alive == 1 and p.collider:getY() or 0
+        local pp    = (pendingpower and pendingpower[i]) or 0
+        data = data .. love.data.pack("string", "fffBBB",
+            x, y, p.angle, alive, p.totalbullets or 0, pp)
+    end
+
+    -- Collect active bullet-shoot bodies from all players
+    local blist = {}
+    for i, pbullets in ipairs(allBullets) do
+        for _, bobj in pairs(pbullets) do
+            for _, sh in pairs(bobj.shoots) do
+                if sh.body then
+                    blist[#blist+1] = { x=sh:getX(), y=sh:getY(), owner=i }
+                end
+            end
+        end
+    end
+    local nb = math.min(#blist, 200)
+    data = data .. love.data.pack("string", "B", nb)
+    for k = 1, nb do
+        data = data .. love.data.pack("string", "ffB",
+            blist[k].x, blist[k].y, blist[k].owner)
+    end
+
+    -- Collect active powerup boxes
+    local plist = {}
+    for _, sup in pairs(Powersuplier) do
+        for _, box in pairs(sup.dabba) do
+            if box.body then
+                plist[#plist+1] = { x=box:getX(), y=box:getY(), choice=box.choice }
+            end
+        end
+    end
+    local np = math.min(#plist, 50)
+    data = data .. love.data.pack("string", "B", np)
+    for k = 1, np do
+        data = data .. love.data.pack("string", "ffB",
+            plist[k].x, plist[k].y, plist[k].choice)
+    end
+
+    data = data .. love.data.pack("string", "BB", gameOver and 1 or 0, winnerId or 0)
+    return data
+end
+
+-- ── Decoder ──────────────────────────────────────────────────────────────────
+-- Parses any incoming packet.  Returns a typed table or nil on error.
+function net.decode(raw)
+    if not raw or #raw < 1 then return nil end
+    local msgType = love.data.unpack("B", raw, 1)
+
+    if msgType == net.MSG_INPUT then
+        if #raw < 4 then return nil end
+        local _, r, s, u = love.data.unpack("BBBB", raw, 1)
+        return { type=net.MSG_INPUT, rotate=r==1, shoot=s==1, usepower=u==1 }
+
+    elseif msgType == net.MSG_STATE then
+        local msg = { type=net.MSG_STATE, players={}, bullets={}, powerups={} }
+        local _, np, pos = love.data.unpack("BB", raw, 1)
+        for _ = 1, np do
+            local x, y, ang, alive, tb, pp, npos = love.data.unpack("fffBBB", raw, pos)
+            msg.players[#msg.players+1] = {
+                x=x, y=y, angle=ang,
+                alive=(alive==1), totalbullets=tb, pendingpower=pp,
+            }
+            pos = npos
+        end
+        local nb, bpos = love.data.unpack("B", raw, pos)
+        pos = bpos
+        for _ = 1, nb do
+            local bx, by, bo, npos = love.data.unpack("ffB", raw, pos)
+            msg.bullets[#msg.bullets+1] = { x=bx, y=by, owner=bo }
+            pos = npos
+        end
+        local npu, ppos = love.data.unpack("B", raw, pos)
+        pos = ppos
+        for _ = 1, npu do
+            local px, py, pc, npos = love.data.unpack("ffB", raw, pos)
+            msg.powerups[#msg.powerups+1] = { x=px, y=py, choice=pc }
+            pos = npos
+        end
+        local go, wi = love.data.unpack("BB", raw, pos)
+        msg.gameOver = (go == 1)
+        msg.winnerId = wi
+        return msg
+
+    elseif msgType == net.MSG_START then
+        return { type=net.MSG_START }
+
+    elseif msgType == net.MSG_GAMEOVER then
+        if #raw < 2 then return nil end
+        local _, wi = love.data.unpack("BB", raw, 1)
+        return { type=net.MSG_GAMEOVER, winnerId=wi }
+    end
+
+    return nil
+end
+
+return net

--- a/modules/net.lua
+++ b/modules/net.lua
@@ -19,17 +19,17 @@ net.TICK_RATE = 1 / 20   -- host broadcasts state 20 times per second
 
 -- ── Helpers ──────────────────────────────────────────────────────────────────
 -- Returns the LAN IP of this machine using the UDP-routing trick (no data sent).
+-- UDP sockets use setpeername() not connect() — connect() is TCP only.
 function net.getLocalIP()
-    local ok, socket = pcall(require, "socket")
-    if ok and socket then
+    local ok, ip = pcall(function()
+        local socket = require("socket")
         local s = socket.udp()
-        if s then
-            s:connect("8.8.8.8", 1)
-            local ip = s:getsockname()
-            s:close()
-            if ip and ip ~= "0.0.0.0" then return ip end
-        end
-    end
+        s:setpeername("8.8.8.8", 1)   -- UDP: setpeername, not connect
+        local addr = s:getsockname()
+        s:close()
+        return addr
+    end)
+    if ok and ip and ip ~= "0.0.0.0" then return ip end
     return "see System Preferences › Network"
 end
 

--- a/modules/net.lua
+++ b/modules/net.lua
@@ -15,7 +15,7 @@ net.MSG_START    = 3   -- host → client : "game is starting now"
 net.MSG_GAMEOVER = 4   -- host → client : winner announced
 
 net.PORT      = 22122
-net.TICK_RATE = 1 / 20   -- host broadcasts state 20 times per second
+net.TICK_RATE = 1 / 60   -- broadcast every frame for smooth client rendering
 
 -- ── Helpers ──────────────────────────────────────────────────────────────────
 -- Returns the LAN IP of this machine using the UDP-routing trick (no data sent).
@@ -57,14 +57,13 @@ function net.encodeInput(rotate, shoot, usepower)
 end
 
 -- ── Full state encoder ────────────────────────────────────────────────────────
--- players      = PlayState.players  (array of Player objects)
--- allBullets   = PlayState.allBullets
--- Powersuplier = PlayState.Powersuplier
--- pendingpower = PlayState.pendingpower  (table indexed by player id)
--- gameOver, winnerId : end-of-round flags
-function net.encodeState(players, allBullets, Powersuplier, pendingpower, gameOver, winnerId)
+-- Encodes the complete visual snapshot of the game that the client needs to
+-- render an identical frame.  All weapon types are included.
+function net.encodeState(players, allBullets, Powersuplier, pendingpower,
+                         gameOver, winnerId, lasers, bombs, scattershots)
     local data = love.data.pack("string", "BB", net.MSG_STATE, #players)
 
+    -- Per-player header
     for i, p in ipairs(players) do
         local alive = (p.collider and p.collider.body) and 1 or 0
         local x     = alive == 1 and p.collider:getX() or 0
@@ -74,41 +73,94 @@ function net.encodeState(players, allBullets, Powersuplier, pendingpower, gameOv
             x, y, p.angle, alive, p.totalbullets or 0, pp)
     end
 
-    -- Collect active bullet-shoot bodies from all players
+    -- Regular bullets (shoots table inside each bullets object)
     local blist = {}
     for i, pbullets in ipairs(allBullets) do
         for _, bobj in pairs(pbullets) do
             for _, sh in pairs(bobj.shoots) do
-                if sh.body then
-                    blist[#blist+1] = { x=sh:getX(), y=sh:getY(), owner=i }
-                end
+                if sh.body then blist[#blist+1] = {x=sh:getX(), y=sh:getY(), owner=i} end
             end
         end
     end
     local nb = math.min(#blist, 200)
     data = data .. love.data.pack("string", "B", nb)
     for k = 1, nb do
-        data = data .. love.data.pack("string", "ffB",
-            blist[k].x, blist[k].y, blist[k].owner)
+        data = data .. love.data.pack("string", "ffB", blist[k].x, blist[k].y, blist[k].owner)
     end
 
-    -- Collect active powerup boxes
+    -- Powerup boxes
     local plist = {}
     for _, sup in pairs(Powersuplier) do
         for _, box in pairs(sup.dabba) do
-            if box.body then
-                plist[#plist+1] = { x=box:getX(), y=box:getY(), choice=box.choice }
-            end
+            if box.body then plist[#plist+1] = {x=box:getX(), y=box:getY(), choice=box.choice} end
         end
     end
     local np = math.min(#plist, 50)
     data = data .. love.data.pack("string", "B", np)
     for k = 1, np do
-        data = data .. love.data.pack("string", "ffB",
-            plist[k].x, plist[k].y, plist[k].choice)
+        data = data .. love.data.pack("string", "ffB", plist[k].x, plist[k].y, plist[k].choice)
     end
 
+    -- End-of-round flags
     data = data .. love.data.pack("string", "BB", gameOver and 1 or 0, winnerId or 0)
+
+    -- Lasers: endpoint pair (x1,y1)→(x2,y2); alive only
+    local llist = {}
+    if lasers then
+        for _, pl in ipairs(lasers) do
+            for _, laser in pairs(pl) do
+                if laser.laser and laser.laser.body then
+                    llist[#llist+1] = {x1=laser.x1, y1=laser.y1, x2=laser.x2, y2=laser.y2}
+                end
+            end
+        end
+    end
+    local nl = math.min(#llist, 20)
+    data = data .. love.data.pack("string", "B", nl)
+    for k = 1, nl do
+        local l = llist[k]
+        data = data .. love.data.pack("string", "ffff", l.x1, l.y1, l.x2, l.y2)
+    end
+
+    -- Bombs: collider position + growing explosion radius
+    local bomlist = {}
+    if bombs then
+        for _, pb in ipairs(bombs) do
+            for _, bomb in pairs(pb) do
+                if bomb.collider and bomb.collider.body then
+                    bomlist[#bomlist+1] = {
+                        x = bomb.collider:getX(),
+                        y = bomb.collider:getY(),
+                        r = bomb.growingradius,
+                    }
+                end
+            end
+        end
+    end
+    local nbom = math.min(#bomlist, 20)
+    data = data .. love.data.pack("string", "B", nbom)
+    for k = 1, nbom do
+        local b = bomlist[k]
+        data = data .. love.data.pack("string", "fff", b.x, b.y, b.r)
+    end
+
+    -- Scatter shots: each individual shot body position
+    local slist = {}
+    if scattershots then
+        for _, ps in ipairs(scattershots) do
+            for _, ss in pairs(ps) do
+                for _, shot in pairs(ss.shots) do
+                    if shot.body then slist[#slist+1] = {x=shot:getX(), y=shot:getY()} end
+                end
+            end
+        end
+    end
+    local ns = math.min(#slist, 200)
+    data = data .. love.data.pack("string", "B", ns)
+    for k = 1, ns do
+        data = data .. love.data.pack("string", "ff", slist[k].x, slist[k].y)
+    end
+
     return data
 end
 
@@ -124,13 +176,16 @@ function net.decode(raw)
         return { type=net.MSG_INPUT, rotate=r==1, shoot=s==1, usepower=u==1 }
 
     elseif msgType == net.MSG_STATE then
-        local msg = { type=net.MSG_STATE, players={}, bullets={}, powerups={} }
+        local msg = {
+            type=net.MSG_STATE,
+            players={}, bullets={}, powerups={},
+            lasers={}, bombs={}, scattershots={},
+        }
         local _, np, pos = love.data.unpack("BB", raw, 1)
         for _ = 1, np do
             local x, y, ang, alive, tb, pp, npos = love.data.unpack("fffBBB", raw, pos)
             msg.players[#msg.players+1] = {
-                x=x, y=y, angle=ang,
-                alive=(alive==1), totalbullets=tb, pendingpower=pp,
+                x=x, y=y, angle=ang, alive=(alive==1), totalbullets=tb, pendingpower=pp,
             }
             pos = npos
         end
@@ -148,9 +203,34 @@ function net.decode(raw)
             msg.powerups[#msg.powerups+1] = { x=px, y=py, choice=pc }
             pos = npos
         end
-        local go, wi = love.data.unpack("BB", raw, pos)
+        local go, wi, gopos = love.data.unpack("BB", raw, pos)
         msg.gameOver = (go == 1)
         msg.winnerId = wi
+        pos = gopos
+        -- Lasers
+        local nl, lpos = love.data.unpack("B", raw, pos)
+        pos = lpos
+        for _ = 1, nl do
+            local x1, y1, x2, y2, npos = love.data.unpack("ffff", raw, pos)
+            msg.lasers[#msg.lasers+1] = {x1=x1, y1=y1, x2=x2, y2=y2}
+            pos = npos
+        end
+        -- Bombs
+        local nbom, bompos = love.data.unpack("B", raw, pos)
+        pos = bompos
+        for _ = 1, nbom do
+            local bx, by, br, npos = love.data.unpack("fff", raw, pos)
+            msg.bombs[#msg.bombs+1] = {x=bx, y=by, r=br}
+            pos = npos
+        end
+        -- Scatter shots
+        local ns, spos = love.data.unpack("B", raw, pos)
+        pos = spos
+        for _ = 1, ns do
+            local sx, sy, npos = love.data.unpack("ff", raw, pos)
+            msg.scattershots[#msg.scattershots+1] = {x=sx, y=sy}
+            pos = npos
+        end
         return msg
 
     elseif msgType == net.MSG_START then

--- a/modules/physics.lua
+++ b/modules/physics.lua
@@ -1,0 +1,58 @@
+-- modules/physics.lua  ─ Pure math helpers (no LÖVE dependency)
+-- Extracted from states/PlayState.lua so the logic is unit-testable in plain Lua.
+
+local physics = {}
+
+-- Lua 5.3+ uses math.atan(y, x); LuaJIT 2.1 (LÖVE 11.x) still provides math.atan2.
+local atan2 = math.atan2 or math.atan
+
+-- Equal-mass elastic collision between two circular bodies.
+--
+-- Each body is a plain table: { x, y, angle, speed, radius }
+--   x, y     — position
+--   angle    — heading (radians); velocity is (cos*angle * speed, sin*angle * speed)
+--   speed    — scalar speed along `angle`
+--   radius   — collision radius (read-only)
+--
+-- Mutates a.x/a.y/a.angle/a.speed and b.x/b.y/b.angle/b.speed in place
+-- when the bodies overlap. Returns nothing.
+function physics.resolveElasticCollision(a, b)
+    local dx   = b.x - a.x
+    local dy   = b.y - a.y
+    local dist = math.sqrt(dx * dx + dy * dy)
+    local minDist = a.radius + b.radius
+    if dist >= minDist or dist <= 0 then return end
+
+    local nx = dx / dist
+    local ny = dy / dist
+    local vax = math.cos(a.angle) * a.speed
+    local vay = math.sin(a.angle) * a.speed
+    local vbx = math.cos(b.angle) * b.speed
+    local vby = math.sin(b.angle) * b.speed
+    local van = vax * nx + vay * ny
+    local vbn = vbx * nx + vby * ny
+
+    if van - vbn > 0 then   -- only resolve if approaching
+        local r = 0.75
+        local new_van = vbn * r
+        local new_vbn = van * r
+        local new_vax = vax + (new_van - van) * nx
+        local new_vay = vay + (new_van - van) * ny
+        local new_vbx = vbx + (new_vbn - vbn) * nx
+        local new_vby = vby + (new_vbn - vbn) * ny
+        local spda = math.sqrt(new_vax * new_vax + new_vay * new_vay)
+        local spdb = math.sqrt(new_vbx * new_vbx + new_vby * new_vby)
+        local MIN_SPEED, MAX_SPEED = 180, 350
+        a.speed = math.max(MIN_SPEED, math.min(MAX_SPEED, spda))
+        b.speed = math.max(MIN_SPEED, math.min(MAX_SPEED, spdb))
+        if spda > 0.1 then a.angle = atan2(new_vay, new_vax) end
+        if spdb > 0.1 then b.angle = atan2(new_vby, new_vbx) end
+    end
+    local overlap = (minDist - dist) / 2 + 1
+    a.x = a.x - nx * overlap
+    a.y = a.y - ny * overlap
+    b.x = b.x + nx * overlap
+    b.y = b.y + ny * overlap
+end
+
+return physics

--- a/spec/helper.lua
+++ b/spec/helper.lua
@@ -1,0 +1,32 @@
+-- spec/helper.lua ─ Minimal LÖVE stub for unit tests of pure modules.
+--
+-- modules/net.lua is the only production module under test that touches the
+-- LÖVE API, and only through love.data.pack / love.data.unpack.  Lua 5.3+
+-- ships string.pack / string.unpack with the same format strings we use
+-- ("B", "BB", "f", "ff", "BBBB", "fffBBB", "ffff", "fff", …), so a
+-- pass-through implementation is sufficient for round-trip tests.
+--
+-- This file is intentionally standalone so individual spec files can load it
+-- with `require 'spec.helper'` regardless of whether busted is invoked from
+-- the project root or the spec/ directory.
+
+local M = {}
+
+love = love or {}
+love.data = love.data or {}
+
+if not love.data.pack then
+    -- `container` is ignored: LÖVE accepts "string" or "data"; we always return
+    -- a plain Lua string which is what net.lua feeds back into love.data.unpack.
+    function love.data.pack(_container, fmt, ...)
+        return string.pack(fmt, ...)
+    end
+end
+
+if not love.data.unpack then
+    function love.data.unpack(fmt, data, pos)
+        return string.unpack(fmt, data, pos)
+    end
+end
+
+return M

--- a/spec/net_spec.lua
+++ b/spec/net_spec.lua
@@ -1,0 +1,149 @@
+-- spec/net_spec.lua ─ busted tests for modules.net encode/decode round-trips.
+-- Uses spec/helper.lua to stub love.data.pack / love.data.unpack with the
+-- pure-Lua string.pack / string.unpack equivalents.
+
+require 'spec.helper'
+local net = require 'modules.net'
+
+-- ── Tiny collider fixture ────────────────────────────────────────────────────
+-- Mimics the subset of the windfield collider API that modules/net.lua reads:
+--   body   — truthy flag ("is this collider alive?")
+--   :getX() / :getY() — current position
+local function fakeCollider(x, y)
+    return {
+        body  = true,
+        getX  = function(self) return self._x end,
+        getY  = function(self) return self._y end,
+        _x = x, _y = y,
+    }
+end
+
+describe("net encode/decode round-trips", function()
+
+    it("MSG_START: decodes back to a MSG_START table", function()
+        local raw = net.encodeStart()
+        local msg = net.decode(raw)
+        assert.are.equal(net.MSG_START, msg.type)
+    end)
+
+    it("MSG_GAMEOVER: preserves winnerId and per-player scores", function()
+        local raw = net.encodeGameOver(2, 3, 4)
+        local msg = net.decode(raw)
+        assert.are.equal(net.MSG_GAMEOVER, msg.type)
+        assert.are.equal(2, msg.winnerId)
+        assert.are.equal(3, msg.p1score)
+        assert.are.equal(4, msg.p2score)
+    end)
+
+    it("MSG_GAMEOVER: clamps scores above 255 into a byte (protocol limit)", function()
+        local raw = net.encodeGameOver(0, 999, 1000)
+        local msg = net.decode(raw)
+        assert.are.equal(0, msg.winnerId)
+        assert.are.equal(255, msg.p1score)
+        assert.are.equal(255, msg.p2score)
+    end)
+
+    it("MSG_INPUT: boolean flags round-trip true/false combinations", function()
+        local combos = {
+            { true,  true,  true  },
+            { false, false, false },
+            { true,  false, true  },
+            { false, true,  false },
+        }
+        for _, c in ipairs(combos) do
+            local rotate, shoot, usepower = c[1], c[2], c[3]
+            local raw = net.encodeInput(rotate, shoot, usepower)
+            local msg = net.decode(raw)
+            assert.are.equal(net.MSG_INPUT, msg.type)
+            assert.are.equal(rotate,   msg.rotate)
+            assert.are.equal(shoot,    msg.shoot)
+            assert.are.equal(usepower, msg.usepower)
+        end
+    end)
+
+    it("MSG_STATE: round-trips a minimal two-player snapshot with no entities", function()
+        local players = {
+            { collider = fakeCollider(10, 20), angle = 0,           totalbullets = 3 },
+            { collider = fakeCollider(30, 40), angle = math.pi / 2, totalbullets = 1 },
+        }
+        local raw = net.encodeState(players, {}, {}, { [1] = 2, [2] = 0 }, false, 0)
+        local msg = net.decode(raw)
+        assert.are.equal(net.MSG_STATE, msg.type)
+        assert.are.equal(2, #msg.players)
+        assert.are.equal(10, msg.players[1].x)
+        assert.are.equal(20, msg.players[1].y)
+        assert.is_true(msg.players[1].alive)
+        assert.are.equal(3, msg.players[1].totalbullets)
+        assert.are.equal(2, msg.players[1].pendingpower)
+        assert.are.equal(1, msg.players[2].totalbullets)
+        assert.are.equal(false, msg.gameOver)
+        assert.are.equal(0,     msg.winnerId)
+        assert.are.equal(0, #msg.bullets)
+        assert.are.equal(0, #msg.powerups)
+        assert.are.equal(0, #msg.lasers)
+        assert.are.equal(0, #msg.bombs)
+        assert.are.equal(0, #msg.scattershots)
+    end)
+
+    it("MSG_STATE: round-trips bullets, powerups, lasers, bombs, scattershots", function()
+        local players = { { collider = fakeCollider(0, 0), angle = 0, totalbullets = 0 } }
+
+        -- One regular bullet owned by player 1
+        local allBullets = {
+            [1] = { { shoots = { fakeCollider(100, 200) } } },
+        }
+
+        -- One powerup box with choice 2
+        local powersuplier = { {
+            dabba = { (function()
+                local c = fakeCollider(50, 60); c.choice = 2; return c
+            end)() },
+        } }
+
+        -- One laser for player 1
+        local lasers = { [1] = { { laser = { body = true }, x1 = 1, y1 = 2, x2 = 3, y2 = 4 } } }
+
+        -- One bomb for player 1 with a growing explosion radius
+        local bombs = { [1] = { { collider = fakeCollider(70, 80), growingradius = 12 } } }
+
+        -- Two scatter shots emitted by player 1's scattershot emitter
+        local scattershots = { [1] = { {
+            shots = { fakeCollider(5, 6), fakeCollider(7, 8) },
+        } } }
+
+        local raw = net.encodeState(players, allBullets, powersuplier,
+            { [1] = 0 }, true, 1, lasers, bombs, scattershots)
+        local msg = net.decode(raw)
+
+        assert.are.equal(true, msg.gameOver)
+        assert.are.equal(1,    msg.winnerId)
+
+        assert.are.equal(1,   #msg.bullets)
+        assert.are.equal(100, msg.bullets[1].x)
+        assert.are.equal(200, msg.bullets[1].y)
+        assert.are.equal(1,   msg.bullets[1].owner)
+
+        assert.are.equal(1,  #msg.powerups)
+        assert.are.equal(50, msg.powerups[1].x)
+        assert.are.equal(60, msg.powerups[1].y)
+        assert.are.equal(2,  msg.powerups[1].choice)
+
+        assert.are.equal(1, #msg.lasers)
+        assert.are.same({ x1 = 1, y1 = 2, x2 = 3, y2 = 4 }, msg.lasers[1])
+
+        assert.are.equal(1,  #msg.bombs)
+        assert.are.equal(70, msg.bombs[1].x)
+        assert.are.equal(80, msg.bombs[1].y)
+        assert.are.equal(12, msg.bombs[1].r)
+
+        assert.are.equal(2, #msg.scattershots)
+        assert.are.equal(5, msg.scattershots[1].x)
+        assert.are.equal(8, msg.scattershots[2].y)
+    end)
+
+    it("decode returns nil for an empty packet", function()
+        assert.is_nil(net.decode(""))
+        assert.is_nil(net.decode(nil))
+    end)
+
+end)

--- a/spec/physics_spec.lua
+++ b/spec/physics_spec.lua
@@ -1,0 +1,87 @@
+-- spec/physics_spec.lua ─ busted tests for modules.physics
+-- Runs in plain Lua 5.3+ (no LÖVE needed).
+
+require 'spec.helper'
+local physics = require 'modules.physics'
+
+local function body(x, y, angle, speed, radius)
+    return { x = x, y = y, angle = angle, speed = speed, radius = radius }
+end
+
+local function clone(t)
+    local c = {}
+    for k, v in pairs(t) do c[k] = v end
+    return c
+end
+
+describe("physics.resolveElasticCollision", function()
+
+    it("does nothing when bodies are farther apart than the sum of radii", function()
+        local a = body(0,   0, 0,       300, 20)
+        local b = body(100, 0, math.pi, 300, 20)
+        local a0, b0 = clone(a), clone(b)
+        physics.resolveElasticCollision(a, b)
+        assert.are.same(a0, a)
+        assert.are.same(b0, b)
+    end)
+
+    it("does nothing when the two bodies share the same position (dist == 0)", function()
+        local a = body(50, 50, 0,       300, 20)
+        local b = body(50, 50, math.pi, 300, 20)
+        local a0, b0 = clone(a), clone(b)
+        physics.resolveElasticCollision(a, b)
+        assert.are.same(a0, a)
+        assert.are.same(b0, b)
+    end)
+
+    it("pushes overlapping, approaching bodies apart along the collision normal", function()
+        -- Head-on along +x: a moving right (angle 0), b moving left (angle pi).
+        local a = body(0,  0, 0,       300, 20)
+        local b = body(30, 0, math.pi, 300, 20)  -- dist 30, minDist 40 → overlap 10
+        physics.resolveElasticCollision(a, b)
+        -- a is pushed -x, b is pushed +x along the normal (which is +x)
+        assert.is_true(a.x < 0)
+        assert.is_true(b.x > 30)
+        -- Pure x-axis collision: no y displacement.
+        assert.are.equal(0, a.y)
+        assert.are.equal(0, b.y)
+    end)
+
+    it("clamps post-collision speeds into [180, 350]", function()
+        -- Very high speeds should be clamped down to MAX_SPEED=350.
+        local a = body(0,  0, 0,       10000, 20)
+        local b = body(30, 0, math.pi, 10000, 20)
+        physics.resolveElasticCollision(a, b)
+        assert.is_true(a.speed <= 350 + 1e-6)
+        assert.is_true(b.speed <= 350 + 1e-6)
+        assert.is_true(a.speed >= 180 - 1e-6)
+        assert.is_true(b.speed >= 180 - 1e-6)
+    end)
+
+    it("leaves angles / speeds unchanged when bodies are moving apart", function()
+        -- Overlapping but separating: a moving -x, b moving +x → normal-rel vel < 0.
+        local a = body(0,  0, math.pi, 300, 20)
+        local b = body(30, 0, 0,       300, 20)
+        local angA, spdA = a.angle, a.speed
+        local angB, spdB = b.angle, b.speed
+        physics.resolveElasticCollision(a, b)
+        -- Velocity-modifying branch is skipped, so angle/speed are untouched.
+        assert.are.equal(angA, a.angle)
+        assert.are.equal(spdA, a.speed)
+        assert.are.equal(angB, b.angle)
+        assert.are.equal(spdB, b.speed)
+        -- Overlap resolution still runs: positions are pushed apart.
+        assert.is_true(a.x < 0)
+        assert.is_true(b.x > 30)
+    end)
+
+    it("swaps velocity components along the normal for equal-mass bodies", function()
+        -- Head-on along +x at equal speed; the along-normal component is simply
+        -- swapped and scaled by r=0.75, so magnitudes should match post-collision.
+        local a = body(0,  0, 0,       300, 20)
+        local b = body(30, 0, math.pi, 300, 20)
+        physics.resolveElasticCollision(a, b)
+        assert.is_true(math.abs(a.speed - b.speed) < 1e-3)
+    end)
+
+end)

--- a/states/EndState.lua
+++ b/states/EndState.lua
@@ -26,7 +26,13 @@ function EndState:update(dt)
 
 end
 
-function  EndState:exit()
+function EndState:keypressed(key)
+    if key == 'escape' then
+        gStateMachine:change('title')
+    end
+end
+
+function EndState:exit()
     self.sounds:stop()
 end
 
@@ -53,5 +59,5 @@ function EndState:render()
     love.graphics.printf("GAME",0,100,WINDOW_WIDTH,"center")
     love.graphics.printf("END",0,150,WINDOW_WIDTH,"center")
     love.graphics.printf("PRESS ENTER TO PLAY AGAIN",0,450,WINDOW_WIDTH,"center")
-    love.graphics.printf("PRESS ESC TO EXIT",0,600,WINDOW_WIDTH,"center")
+    love.graphics.printf("PRESS ESC FOR MENU",0,600,WINDOW_WIDTH,"center")
 end

--- a/states/LobbyState.lua
+++ b/states/LobbyState.lua
@@ -1,0 +1,179 @@
+-- states/LobbyState.lua  ─ LAN Lobby: choose to Host or Join a game
+LobbyState = Class{__includes = BaseState}
+
+local net = require "modules.net"
+
+-- Internal phase names
+local MENU       = "menu"
+local HOST_WAIT  = "host_wait"    -- server running, waiting for a client
+local HOST_READY = "host_ready"   -- client connected, press ENTER to begin
+local JOIN_INPUT = "join_input"   -- typing in the host's IP address
+local CONNECTING = "connecting"   -- TCP handshake in progress
+
+function LobbyState:init()
+    self.phase   = MENU
+    self.ipInput = ""
+    self.localIP = ""
+    self.errMsg  = ""
+    self.font    = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 36)
+    self.font2   = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 22)
+end
+
+function LobbyState:update(dt)
+    if not NET.host then return end
+
+    if self.phase == HOST_WAIT or self.phase == HOST_READY then
+        local event = NET.host:service(0)
+        while event do
+            if event.type == "connect" then
+                NET.peer   = event.peer
+                self.phase = HOST_READY
+                self.errMsg = ""
+            elseif event.type == "disconnect" then
+                NET.peer    = nil
+                self.phase  = HOST_WAIT
+                self.errMsg = "Client disconnected — waiting again…"
+            end
+            event = NET.host:service(0)
+        end
+
+    elseif self.phase == CONNECTING then
+        local event = NET.host:service(10)
+        while event do
+            if event.type == "connect" then
+                NET.peer    = event.peer
+                self.errMsg = "Connected! Waiting for host to start…"
+            elseif event.type == "receive" then
+                local msg = net.decode(event.data)
+                if msg and msg.type == net.MSG_START then
+                    NET.mode    = "client"
+                    NET.localId = 2
+                    gStateMachine:change("netclient")
+                    return
+                end
+            elseif event.type == "disconnect" then
+                self.errMsg = "Connection refused or timed out"
+                self.phase  = JOIN_INPUT
+                if NET.host then NET.host:destroy() end
+                NET.host = nil
+                NET.peer = nil
+            end
+            event = NET.host:service(10)
+        end
+    end
+end
+
+function LobbyState:keypressed(key)
+    if self.phase == MENU then
+        if key == "h" then
+            NET.host    = net.enet.host_create("*:" .. net.PORT, 1, 2)
+            NET.mode    = "host"
+            NET.localId = 1
+            self.localIP = net.getLocalIP()
+            self.phase   = HOST_WAIT
+        elseif key == "j" then
+            self.phase   = JOIN_INPUT
+            self.ipInput = ""
+            self.errMsg  = ""
+        elseif key == "escape" then
+            gStateMachine:change("title")
+        end
+
+    elseif self.phase == HOST_WAIT then
+        if key == "escape" then self:_cancel() end
+
+    elseif self.phase == HOST_READY then
+        if key == "return" then
+            NET.peer:send(net.encodeStart(), 1, "reliable")
+            gStateMachine:change("play")
+        elseif key == "escape" then
+            self:_cancel()
+        end
+
+    elseif self.phase == JOIN_INPUT then
+        if key == "return" and #self.ipInput > 0 then
+            NET.host      = net.enet.host_create(nil, 1, 2)
+            NET.host:connect(self.ipInput .. ":" .. net.PORT, 2)
+            self.phase    = CONNECTING
+            self.errMsg   = "Connecting to " .. self.ipInput .. "…"
+        elseif key == "backspace" then
+            self.ipInput = self.ipInput:sub(1, -2)
+        elseif key == "escape" then
+            self.phase  = MENU
+            self.errMsg = ""
+        end
+
+    elseif self.phase == CONNECTING then
+        if key == "escape" then
+            if NET.host then NET.host:destroy() end
+            NET.host   = nil
+            NET.peer   = nil
+            NET.mode   = nil
+            self.phase  = JOIN_INPUT
+            self.errMsg = ""
+        end
+    end
+end
+
+-- Called by love.textinput (routed via main.lua) — IP address characters only
+function LobbyState:textinput(t)
+    if self.phase == JOIN_INPUT and t:match("[0-9%.]") then
+        self.ipInput = self.ipInput .. t
+    end
+end
+
+function LobbyState:_cancel()
+    if NET.host then NET.host:destroy() end
+    NET.host   = nil
+    NET.peer   = nil
+    NET.mode   = nil
+    self.phase = MENU
+    self.errMsg = ""
+end
+
+function LobbyState:exit() end   -- host/peer kept alive for PlayState / NetClientState
+
+function LobbyState:render()
+    love.graphics.setColor(0.05, 0.05, 0.15)
+    love.graphics.rectangle("fill", 0, 0, WINDOW_WIDTH, WINDOW_HEIGHT)
+    love.graphics.setColor(1, 1, 1)
+    love.graphics.setFont(self.font)
+    love.graphics.printf("LAN MULTIPLAYER", 0, 80, WINDOW_WIDTH, "center")
+    love.graphics.setFont(self.font2)
+
+    if self.phase == MENU then
+        love.graphics.printf("H  –  HOST GAME",  0, 250, WINDOW_WIDTH, "center")
+        love.graphics.printf("J  –  JOIN GAME",  0, 310, WINDOW_WIDTH, "center")
+        love.graphics.printf("ESC  –  BACK",     0, 370, WINDOW_WIDTH, "center")
+
+    elseif self.phase == HOST_WAIT then
+        love.graphics.printf("Waiting for player to join…",  0, 240, WINDOW_WIDTH, "center")
+        love.graphics.printf("Your IP:  " .. self.localIP,   0, 295, WINDOW_WIDTH, "center")
+        love.graphics.printf("Port:     " .. net.PORT,       0, 340, WINDOW_WIDTH, "center")
+        love.graphics.printf("ESC  –  cancel",               0, 420, WINDOW_WIDTH, "center")
+
+    elseif self.phase == HOST_READY then
+        love.graphics.setColor(0.3, 1, 0.3)
+        love.graphics.printf("Player connected!",        0, 250, WINDOW_WIDTH, "center")
+        love.graphics.setColor(1, 1, 1)
+        love.graphics.printf("ENTER  –  start game",    0, 320, WINDOW_WIDTH, "center")
+        love.graphics.printf("ESC  –  disconnect",      0, 380, WINDOW_WIDTH, "center")
+
+    elseif self.phase == JOIN_INPUT then
+        love.graphics.printf("Enter host IP address:",  0, 220, WINDOW_WIDTH, "center")
+        love.graphics.setColor(0.9, 0.9, 0.4)
+        love.graphics.printf(self.ipInput .. "_",       0, 280, WINDOW_WIDTH, "center")
+        love.graphics.setColor(1, 1, 1)
+        love.graphics.printf("ENTER to connect  |  ESC – back", 0, 350, WINDOW_WIDTH, "center")
+
+    elseif self.phase == CONNECTING then
+        love.graphics.printf(self.errMsg,    0, 300, WINDOW_WIDTH, "center")
+        love.graphics.printf("ESC  –  cancel", 0, 370, WINDOW_WIDTH, "center")
+    end
+
+    if self.errMsg ~= "" and self.phase ~= CONNECTING then
+        love.graphics.setColor(1, 0.4, 0.4)
+        love.graphics.printf(self.errMsg, 0, 500, WINDOW_WIDTH, "center")
+        love.graphics.setColor(1, 1, 1)
+    end
+end

--- a/states/LobbyState.lua
+++ b/states/LobbyState.lua
@@ -1,4 +1,4 @@
--- states/LobbyState.lua  ─ LAN Lobby: choose to Host or Join a game
+-- states/LobbyState.lua  ─ Multiplayer Lobby: Host or Join over LAN or Internet
 LobbyState = Class{__includes = BaseState}
 
 local net = require "modules.net"
@@ -10,16 +10,39 @@ local HOST_READY = "host_ready"   -- client connected, press ENTER to begin
 local JOIN_INPUT = "join_input"   -- typing in the host's IP address
 local CONNECTING = "connecting"   -- TCP handshake in progress
 
+-- Background thread: fetches public IP from ipify.org (non-blocking)
+local PUBIP_THREAD = [[
+    local http = require("socket.http")
+    local chan  = love.thread.getChannel("sw_pubip")
+    local ok, body, code = pcall(http.request, "http://api.ipify.org")
+    if ok and code == 200 and body and #body > 0 then
+        chan:push(body)
+    else
+        chan:push("")
+    end
+]]
+
 function LobbyState:init()
-    self.phase   = MENU
-    self.ipInput = ""
-    self.localIP = ""
-    self.errMsg  = ""
+    self.phase       = MENU
+    self.ipInput     = ""
+    self.localIP     = ""
+    self.publicIP    = ""          -- fetched asynchronously when hosting
+    self.pubIPChan   = love.thread.getChannel("sw_pubip")
+    self.pubIPThread = nil
+    self.errMsg      = ""
     self.font    = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 36)
     self.font2   = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 22)
+    -- Drain any stale result from a previous session
+    while self.pubIPChan:pop() do end
 end
 
-function LobbyState:update(dt)
+function LobbyState:update(_dt)
+    -- Poll public-IP result channel (filled by background thread)
+    local fetchedIP = self.pubIPChan:pop()
+    if fetchedIP then
+        self.publicIP = (#fetchedIP > 0) and fetchedIP or "unavailable"
+    end
+
     if not NET.host then return end
 
     if self.phase == HOST_WAIT or self.phase == HOST_READY then
@@ -69,7 +92,11 @@ function LobbyState:keypressed(key)
             NET.host    = net.enet.host_create("*:" .. net.PORT, 1, 2)
             NET.mode    = "host"
             NET.localId = 1
-            self.localIP = net.getLocalIP()
+            self.localIP  = net.getLocalIP()
+            self.publicIP = "fetching…"
+            -- Launch background thread to fetch public (WAN) IP
+            self.pubIPThread = love.thread.newThread(PUBIP_THREAD)
+            self.pubIPThread:start()
             self.phase   = HOST_WAIT
         elseif key == "j" then
             self.phase   = JOIN_INPUT
@@ -124,11 +151,14 @@ end
 
 function LobbyState:_cancel()
     if NET.host then NET.host:destroy() end
-    NET.host   = nil
-    NET.peer   = nil
-    NET.mode   = nil
-    self.phase = MENU
-    self.errMsg = ""
+    NET.host      = nil
+    NET.peer      = nil
+    NET.mode      = nil
+    self.phase    = MENU
+    self.errMsg   = ""
+    self.publicIP = ""
+    -- Let the background thread finish naturally (it will push to the channel
+    -- which we drain on the next init(), so no cleanup needed here)
 end
 
 function LobbyState:exit() end   -- host/peer kept alive for PlayState / NetClientState
@@ -138,19 +168,29 @@ function LobbyState:render()
     love.graphics.rectangle("fill", 0, 0, WINDOW_WIDTH, WINDOW_HEIGHT)
     love.graphics.setColor(1, 1, 1)
     love.graphics.setFont(self.font)
-    love.graphics.printf("LAN MULTIPLAYER", 0, 80, WINDOW_WIDTH, "center")
+    love.graphics.printf("MULTIPLAYER", 0, 60, WINDOW_WIDTH, "center")
     love.graphics.setFont(self.font2)
 
     if self.phase == MENU then
-        love.graphics.printf("H  –  HOST GAME",  0, 250, WINDOW_WIDTH, "center")
-        love.graphics.printf("J  –  JOIN GAME",  0, 310, WINDOW_WIDTH, "center")
-        love.graphics.printf("ESC  –  BACK",     0, 370, WINDOW_WIDTH, "center")
+        love.graphics.printf("H  –  HOST GAME",  0, 240, WINDOW_WIDTH, "center")
+        love.graphics.printf("J  –  JOIN GAME",  0, 300, WINDOW_WIDTH, "center")
+        love.graphics.printf("ESC  –  BACK",     0, 360, WINDOW_WIDTH, "center")
+        -- Hint about internet play
+        love.graphics.setColor(0.6, 0.6, 0.6)
+        love.graphics.printf("LAN: type the host's LAN IP   |   Internet: type the host's Public IP", 0, 460, WINDOW_WIDTH, "center")
+        love.graphics.setColor(1, 1, 1)
 
     elseif self.phase == HOST_WAIT then
-        love.graphics.printf("Waiting for player to join…",  0, 240, WINDOW_WIDTH, "center")
-        love.graphics.printf("Your IP:  " .. self.localIP,   0, 295, WINDOW_WIDTH, "center")
-        love.graphics.printf("Port:     " .. net.PORT,       0, 340, WINDOW_WIDTH, "center")
-        love.graphics.printf("ESC  –  cancel",               0, 420, WINDOW_WIDTH, "center")
+        love.graphics.printf("Waiting for player to join…",     0, 200, WINDOW_WIDTH, "center")
+        love.graphics.printf("LAN IP:    " .. self.localIP,     0, 255, WINDOW_WIDTH, "center")
+        love.graphics.printf("Public IP: " .. self.publicIP,    0, 290, WINDOW_WIDTH, "center")
+        love.graphics.printf("Port:      " .. net.PORT,         0, 325, WINDOW_WIDTH, "center")
+        -- Internet play instructions
+        love.graphics.setColor(0.9, 0.85, 0.4)
+        love.graphics.printf("Internet play: forward UDP port " .. net.PORT .. " on your router", 0, 375, WINDOW_WIDTH, "center")
+        love.graphics.printf("then share your Public IP with the other player", 0, 405, WINDOW_WIDTH, "center")
+        love.graphics.setColor(1, 1, 1)
+        love.graphics.printf("ESC  –  cancel",                  0, 455, WINDOW_WIDTH, "center")
 
     elseif self.phase == HOST_READY then
         love.graphics.setColor(0.3, 1, 0.3)
@@ -160,11 +200,14 @@ function LobbyState:render()
         love.graphics.printf("ESC  –  disconnect",      0, 380, WINDOW_WIDTH, "center")
 
     elseif self.phase == JOIN_INPUT then
-        love.graphics.printf("Enter host IP address:",  0, 220, WINDOW_WIDTH, "center")
+        love.graphics.printf("Enter host IP address:",  0, 200, WINDOW_WIDTH, "center")
         love.graphics.setColor(0.9, 0.9, 0.4)
-        love.graphics.printf(self.ipInput .. "_",       0, 280, WINDOW_WIDTH, "center")
+        love.graphics.printf(self.ipInput .. "_",       0, 260, WINDOW_WIDTH, "center")
         love.graphics.setColor(1, 1, 1)
-        love.graphics.printf("ENTER to connect  |  ESC – back", 0, 350, WINDOW_WIDTH, "center")
+        love.graphics.printf("ENTER to connect  |  ESC – back", 0, 330, WINDOW_WIDTH, "center")
+        love.graphics.setColor(0.6, 0.6, 0.6)
+        love.graphics.printf("Same WiFi → use LAN IP   |   Internet → use Public IP", 0, 390, WINDOW_WIDTH, "center")
+        love.graphics.setColor(1, 1, 1)
 
     elseif self.phase == CONNECTING then
         love.graphics.printf(self.errMsg,    0, 300, WINDOW_WIDTH, "center")
@@ -173,7 +216,7 @@ function LobbyState:render()
 
     if self.errMsg ~= "" and self.phase ~= CONNECTING then
         love.graphics.setColor(1, 0.4, 0.4)
-        love.graphics.printf(self.errMsg, 0, 500, WINDOW_WIDTH, "center")
+        love.graphics.printf(self.errMsg, 0, 530, WINDOW_WIDTH, "center")
         love.graphics.setColor(1, 1, 1)
     end
 end

--- a/states/NetClientState.lua
+++ b/states/NetClientState.lua
@@ -1,0 +1,186 @@
+-- states/NetClientState.lua  ─ Thin-client game state for LAN player 2
+-- The host runs all physics; this state only sends input and renders received state.
+NetClientState = Class{__includes = BaseState}
+
+local net = require "modules.net"
+
+local POWER_NAMES = { [1]="Laser", [2]="Bomb", [3]="Scatter", [4]="Reverse" }
+local HUD_COLORS  = { {1,0.9,0.2}, {0.3,0.9,1}, {0.3,1,0.3}, {1,0.5,0.3} }
+local HUD_X       = { 20, WINDOW_WIDTH - 230 }
+
+function NetClientState:init()
+    -- Game state received from host (updated by MSG_STATE packets)
+    self.playerData  = {}
+    self.bulletData  = {}
+    self.powerupData = {}
+    self.gameOver    = false
+    self.winnerId    = 0
+    self.endTimer    = 0
+
+    -- Pending one-shot input flags; cleared after each send
+    self.pendingShoot    = false
+    self.pendingUsepower = false
+    self.sendTimer       = 0
+
+    -- Assets (mirrors PlayState assets so rendering is consistent)
+    self.background   = love.graphics.newImage("assets/Background/b3.png")
+    self.playerimages = {
+        love.graphics.newImage("assets/player1.png"),
+        love.graphics.newImage("assets/player2.png"),
+    }
+    self.powerupimage = love.graphics.newImage("assets/powersupplier.png")
+    self.font         = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 22)
+    self.font2        = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 48)
+
+    -- Map rects (must match PlayState's layout)
+    self.mapRects = {
+        {300,150,50,175}, {125,325,175,50},
+        {300,375,50,175}, {350,325,175,50},
+        {800,150,50,175}, {625,325,175,50},
+        {800,375,50,175}, {850,325,175,50},
+    }
+end
+
+function NetClientState:update(dt)
+    -- 1) Poll enet for incoming messages from the host
+    if NET.host then
+        local event = NET.host:service(0)
+        while event do
+            if event.type == "receive" then
+                local msg = net.decode(event.data)
+                if msg then
+                    if msg.type == net.MSG_STATE then
+                        self.playerData  = msg.players
+                        self.bulletData  = msg.bullets
+                        self.powerupData = msg.powerups
+                        if msg.gameOver and not self.gameOver then
+                            self.gameOver = true
+                            self.winnerId = msg.winnerId
+                        end
+                    elseif msg.type == net.MSG_GAMEOVER then
+                        self.gameOver = true
+                        self.winnerId = msg.winnerId
+                    end
+                end
+            elseif event.type == "disconnect" then
+                self:_cleanup()
+                gStateMachine:change("title")
+                return
+            end
+            event = NET.host:service(0)
+        end
+    end
+
+    -- 2) Game-over: wait 3 s then return to title
+    if self.gameOver then
+        self.endTimer = self.endTimer + dt
+        if self.endTimer > 3 then
+            self:_cleanup()
+            gStateMachine:change("title")
+        end
+        return
+    end
+
+    -- 3) Send our input to the host every frame (~60 Hz)
+    self.sendTimer = self.sendTimer + dt
+    if self.sendTimer >= 1/60 and NET.peer then
+        self.sendTimer = 0
+        local lid    = NET.localId or 2
+        local rotate = KEY_BINDINGS[lid] and love.keyboard.isDown(KEY_BINDINGS[lid].rotate) or false
+        NET.peer:send(net.encodeInput(rotate, self.pendingShoot, self.pendingUsepower), 0, "unreliable")
+        self.pendingShoot    = false
+        self.pendingUsepower = false
+    end
+end
+
+function NetClientState:keypressed(key)
+    if key == "escape" then
+        self:_cleanup()
+        gStateMachine:change("title")
+        return
+    end
+    local lid = NET.localId or 2
+    if KEY_BINDINGS[lid] then
+        if key == KEY_BINDINGS[lid].shoot    then self.pendingShoot    = true end
+        if key == KEY_BINDINGS[lid].usepower then self.pendingUsepower = true end
+    end
+end
+
+function NetClientState:_cleanup()
+    if NET.host then NET.host:destroy() end
+    NET.host    = nil
+    NET.peer    = nil
+    NET.mode    = nil
+    NET.localId = 1
+end
+
+function NetClientState:exit() end
+
+function NetClientState:render()
+    -- Background
+    love.graphics.draw(self.background, 0, 0, 0,
+        WINDOW_WIDTH  / self.background:getWidth(),
+        WINDOW_HEIGHT / self.background:getHeight())
+
+    -- Map obstacles
+    love.graphics.setColor(0.9, 0.4, 0.4)
+    for _, r in ipairs(self.mapRects) do
+        love.graphics.rectangle("fill", r[1], r[2], r[3], r[4])
+    end
+    love.graphics.setColor(1, 1, 1)
+
+    -- Players (positions received from host)
+    for i, pd in ipairs(self.playerData) do
+        if pd.alive then
+            local img = self.playerimages[i]
+            if img then
+                love.graphics.draw(img, pd.x, pd.y,
+                    pd.angle + 359.75, 1, 1,
+                    img:getWidth()/2, img:getHeight()/2)
+            else
+                local c = HUD_COLORS[i] or {1,1,1}
+                love.graphics.setColor(c[1], c[2], c[3])
+                love.graphics.circle("fill", pd.x, pd.y, 30)
+                love.graphics.setColor(1, 1, 1)
+            end
+        end
+    end
+
+    -- Bullets (dots; no physics on client)
+    love.graphics.setColor(1, 1, 0.5)
+    for _, b in ipairs(self.bulletData) do
+        love.graphics.circle("fill", b.x, b.y, 3)
+    end
+    love.graphics.setColor(1, 1, 1)
+
+    -- Powerup boxes
+    for _, p in ipairs(self.powerupData) do
+        love.graphics.draw(self.powerupimage, p.x - 17, p.y - 19, 0, 0.3, 0.3)
+    end
+
+    -- HUD: power name per player
+    love.graphics.setFont(self.font)
+    for i, pd in ipairs(self.playerData) do
+        if pd.pendingpower and pd.pendingpower > 0 then
+            local c = HUD_COLORS[i] or {1,1,1}
+            love.graphics.setColor(c[1], c[2], c[3])
+            local key = KEY_BINDINGS[i] and KEY_BINDINGS[i].usepower or "?"
+            love.graphics.print(
+                "P"..i.." Power: "..(POWER_NAMES[pd.pendingpower] or "?").."  ["..key.."]",
+                HUD_X[i] or 20, 20)
+            love.graphics.setColor(1, 1, 1)
+        end
+    end
+
+    -- Game-over overlay
+    if self.gameOver then
+        love.graphics.setColor(0, 0, 0, 0.65)
+        love.graphics.rectangle("fill", 0, 0, WINDOW_WIDTH, WINDOW_HEIGHT)
+        love.graphics.setColor(1, 1, 1)
+        love.graphics.setFont(self.font2)
+        local txt = self.winnerId > 0
+            and ("Player " .. self.winnerId .. " Wins!")
+            or  "Draw!"
+        love.graphics.printf(txt, 0, WINDOW_HEIGHT/2 - 50, WINDOW_WIDTH, "center")
+    end
+end

--- a/states/NetClientState.lua
+++ b/states/NetClientState.lua
@@ -29,6 +29,7 @@ function NetClientState:init()
         love.graphics.newImage("assets/player2.png"),
     }
     self.powerupimage = love.graphics.newImage("assets/powersupplier.png")
+    self.bulletimage  = love.graphics.newImage("assets/Bullet 5x5.png")
     self.font         = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 22)
     self.font2        = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 48)
 
@@ -58,8 +59,14 @@ function NetClientState:update(dt)
                             self.winnerId = msg.winnerId
                         end
                     elseif msg.type == net.MSG_GAMEOVER then
-                        self.gameOver = true
-                        self.winnerId = msg.winnerId
+                        -- Sync score globals so NewScoreState renders correctly
+                        PLAYER1_SCORE = msg.p1score or PLAYER1_SCORE
+                        PLAYER2_SCORE = msg.p2score or PLAYER2_SCORE
+                        PLAYER_SCORES[1] = PLAYER1_SCORE
+                        PLAYER_SCORES[2] = PLAYER2_SCORE
+                        local winner = (msg.winnerId == 1) and "player1" or "player2"
+                        gStateMachine:change('newScore', winner)
+                        return
                     end
                 end
             elseif event.type == "disconnect" then
@@ -71,17 +78,7 @@ function NetClientState:update(dt)
         end
     end
 
-    -- 2) Game-over: show overlay for 4 s then start a fresh NetClientState for
-    --    the next round.  The enet connection is kept alive — do NOT clean up.
-    if self.gameOver then
-        self.endTimer = self.endTimer + dt
-        if self.endTimer > 4 then
-            -- Re-enter this state fresh; host will have returned to PlayState
-            -- and will begin broadcasting the new round's state automatically.
-            gStateMachine:change("netclient")
-        end
-        return
-    end
+    -- (Game-over is now handled immediately via MSG_GAMEOVER → newScore transition)
 
     -- 3) Send our input to the host every frame (~60 Hz)
     self.sendTimer = self.sendTimer + dt
@@ -148,12 +145,10 @@ function NetClientState:render()
         end
     end
 
-    -- Bullets (dots; no physics on client)
-    love.graphics.setColor(1, 1, 0.5)
+    -- Bullets — same image and scale as bullets:render() on the host
     for _, b in ipairs(self.bulletData) do
-        love.graphics.circle("fill", b.x, b.y, 3)
+        love.graphics.draw(self.bulletimage, b.x - 3, b.y - 3, 0, 1.7, 1.7)
     end
-    love.graphics.setColor(1, 1, 1)
 
     -- Powerup boxes
     for _, p in ipairs(self.powerupData) do
@@ -183,15 +178,4 @@ function NetClientState:render()
         love.graphics.printf("Waiting for next round…", 0, WINDOW_HEIGHT/2 - 20, WINDOW_WIDTH, "center")
     end
 
-    -- Game-over overlay
-    if self.gameOver then
-        love.graphics.setColor(0, 0, 0, 0.65)
-        love.graphics.rectangle("fill", 0, 0, WINDOW_WIDTH, WINDOW_HEIGHT)
-        love.graphics.setColor(1, 1, 1)
-        love.graphics.setFont(self.font2)
-        local txt = self.winnerId > 0
-            and ("Player " .. self.winnerId .. " Wins!")
-            or  "Draw!"
-        love.graphics.printf(txt, 0, WINDOW_HEIGHT/2 - 50, WINDOW_WIDTH, "center")
-    end
 end

--- a/states/NetClientState.lua
+++ b/states/NetClientState.lua
@@ -4,9 +4,9 @@ NetClientState = Class{__includes = BaseState}
 
 local net = require "modules.net"
 
-local POWER_NAMES = { [1]="Laser", [2]="Bomb", [3]="Scatter", [4]="Reverse" }
+local POWER_NAMES = { [1]="Laser", [2]="Bomb", [3]="Scatter Shot", [4]="Reverse" }
 local HUD_COLORS  = { {1,0.9,0.2}, {0.3,0.9,1}, {0.3,1,0.3}, {1,0.5,0.3} }
-local HUD_X       = { 20, WINDOW_WIDTH - 230 }
+local HUD_X       = { 20, WINDOW_WIDTH - 220 }   -- matches PlayState hudX exactly
 
 function NetClientState:init()
     -- Game state received from host (updated by MSG_STATE packets)
@@ -19,7 +19,10 @@ function NetClientState:init()
     self.gameOver      = false
     self.winnerId      = 0
     self.endTimer      = 0
-    self.display       = 0   -- mirrors PlayState.display; drives bomb warning-circle flash
+    self.display       = 0   -- drives bomb warning-circle flash (local timer, same period as host)
+
+    -- Per-player bullet-orbit animation angle (advances at 4 rad/s, same as Player.bulletangle)
+    self.bulletAngles  = { 0, 0, 0, 0 }
 
     -- Pending one-shot input flags; cleared after each send
     self.pendingShoot    = false
@@ -39,6 +42,16 @@ function NetClientState:init()
     self.font         = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 22)
     self.font2        = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 48)
 
+    -- Sounds — same files and volumes as PlayState
+    self.sounds      = love.audio.newSource("assets/Sounds/Space Heroes.ogg", "static")
+    self.sounds:setVolume(0.18)
+    self.sounds:setLooping(true)
+    self.sounds:play()
+    self.blastsound  = love.audio.newSource("assets/Sounds/deathexplosion.mp3", "static")
+    self.blastsound:setVolume(0.5)
+    self.bulletsound = love.audio.newSource("assets/Sounds/bulletshootsound.mp3", "static")
+    self.bulletsound:setVolume(0.2)
+
     -- Map rects (must match PlayState's layout)
     self.mapRects = {
         {300,150,50,175}, {125,325,175,50},
@@ -57,6 +70,13 @@ function NetClientState:update(dt)
                 local msg = net.decode(event.data)
                 if msg then
                     if msg.type == net.MSG_STATE then
+                        -- Death detection: play explosion when a player transitions alive→dead
+                        for i, pd in ipairs(msg.players) do
+                            local prev = self.playerData[i]
+                            if prev and prev.alive and not pd.alive then
+                                self.blastsound:play()
+                            end
+                        end
                         self.playerData  = msg.players
                         self.bulletData  = msg.bullets
                         self.powerupData = msg.powerups
@@ -89,6 +109,11 @@ function NetClientState:update(dt)
 
     -- (Game-over is now handled immediately via MSG_GAMEOVER → newScore transition)
 
+    -- Advance per-player bullet-orbit angles at the same rate as Player.bulletangle (4 rad/s)
+    for i = 1, 4 do
+        self.bulletAngles[i] = self.bulletAngles[i] + 4 * dt
+    end
+
     -- Advance bomb warning-circle flash timer (mirrors PlayState.display)
     self.display = self.display + dt
     if self.display > 3 then self.display = 0 end
@@ -113,12 +138,16 @@ function NetClientState:keypressed(key)
     end
     local lid = NET.localId or 2
     if KEY_BINDINGS[lid] then
-        if key == KEY_BINDINGS[lid].shoot    then self.pendingShoot    = true end
+        if key == KEY_BINDINGS[lid].shoot then
+            self.bulletsound:play()   -- same as PlayState:keypressed() — plays on key, host decides if bullet fires
+            self.pendingShoot = true
+        end
         if key == KEY_BINDINGS[lid].usepower then self.pendingUsepower = true end
     end
 end
 
 function NetClientState:_cleanup()
+    self.sounds:stop()
     if NET.host then NET.host:destroy() end
     NET.host    = nil
     NET.peer    = nil
@@ -126,7 +155,10 @@ function NetClientState:_cleanup()
     NET.localId = 1
 end
 
-function NetClientState:exit() end
+function NetClientState:exit()
+    -- Stop background music so it doesn't bleed into the score screen
+    self.sounds:stop()
+end
 
 function NetClientState:render()
     -- Background
@@ -141,7 +173,7 @@ function NetClientState:render()
     end
     love.graphics.setColor(1, 1, 1)
 
-    -- Players — mirrors PlayState:render() player draw
+    -- Players — ship image, mirrors PlayState:render()
     for i, pd in ipairs(self.playerData) do
         if pd.alive then
             local img = self.playerimages[i]
@@ -154,6 +186,25 @@ function NetClientState:render()
                 love.graphics.setColor(c[1], c[2], c[3])
                 love.graphics.circle("fill", pd.x, pd.y, 30)
                 love.graphics.setColor(1, 1, 1)
+            end
+        end
+    end
+
+    -- Orbiting bullet-count dots — mirrors Player:render() exactly
+    -- (ba+360 / ba / ba-360 offsets match the original code; they differ by ~0.18 rad)
+    for i, pd in ipairs(self.playerData) do
+        if pd.alive then
+            local ba = self.bulletAngles[i]
+            local tb = pd.totalbullets or 0
+            if tb >= 3 then
+                love.graphics.draw(self.bulletimage, pd.x+40*math.cos(ba+360), pd.y+40*math.sin(ba+360))
+                love.graphics.draw(self.bulletimage, pd.x+40*math.cos(ba),     pd.y+40*math.sin(ba))
+                love.graphics.draw(self.bulletimage, pd.x+40*math.cos(ba-360), pd.y+40*math.sin(ba-360))
+            elseif tb == 2 then
+                love.graphics.draw(self.bulletimage, pd.x+40*math.cos(ba+360), pd.y+40*math.sin(ba+360))
+                love.graphics.draw(self.bulletimage, pd.x+40*math.cos(ba),     pd.y+40*math.sin(ba))
+            elseif tb == 1 then
+                love.graphics.draw(self.bulletimage, pd.x+40*math.cos(ba),     pd.y+40*math.sin(ba))
             end
         end
     end

--- a/states/NetClientState.lua
+++ b/states/NetClientState.lua
@@ -71,12 +71,14 @@ function NetClientState:update(dt)
         end
     end
 
-    -- 2) Game-over: wait 3 s then return to title
+    -- 2) Game-over: show overlay for 4 s then start a fresh NetClientState for
+    --    the next round.  The enet connection is kept alive — do NOT clean up.
     if self.gameOver then
         self.endTimer = self.endTimer + dt
-        if self.endTimer > 3 then
-            self:_cleanup()
-            gStateMachine:change("title")
+        if self.endTimer > 4 then
+            -- Re-enter this state fresh; host will have returned to PlayState
+            -- and will begin broadcasting the new round's state automatically.
+            gStateMachine:change("netclient")
         end
         return
     end
@@ -170,6 +172,15 @@ function NetClientState:render()
                 HUD_X[i] or 20, 20)
             love.graphics.setColor(1, 1, 1)
         end
+    end
+
+    -- "Waiting" overlay when no state has arrived yet (host is in score screen)
+    if #self.playerData == 0 and not self.gameOver then
+        love.graphics.setColor(0, 0, 0, 0.5)
+        love.graphics.rectangle("fill", 0, 0, WINDOW_WIDTH, WINDOW_HEIGHT)
+        love.graphics.setColor(1, 1, 1)
+        love.graphics.setFont(self.font)
+        love.graphics.printf("Waiting for next round…", 0, WINDOW_HEIGHT/2 - 20, WINDOW_WIDTH, "center")
     end
 
     -- Game-over overlay

--- a/states/NetClientState.lua
+++ b/states/NetClientState.lua
@@ -10,19 +10,23 @@ local HUD_X       = { 20, WINDOW_WIDTH - 230 }
 
 function NetClientState:init()
     -- Game state received from host (updated by MSG_STATE packets)
-    self.playerData  = {}
-    self.bulletData  = {}
-    self.powerupData = {}
-    self.gameOver    = false
-    self.winnerId    = 0
-    self.endTimer    = 0
+    self.playerData    = {}
+    self.bulletData    = {}
+    self.powerupData   = {}
+    self.laserData     = {}
+    self.bombData      = {}
+    self.scatterData   = {}
+    self.gameOver      = false
+    self.winnerId      = 0
+    self.endTimer      = 0
+    self.display       = 0   -- mirrors PlayState.display; drives bomb warning-circle flash
 
     -- Pending one-shot input flags; cleared after each send
     self.pendingShoot    = false
     self.pendingUsepower = false
     self.sendTimer       = 0
 
-    -- Assets (mirrors PlayState assets so rendering is consistent)
+    -- Assets — identical to what PlayState and weapon classes load
     self.background   = love.graphics.newImage("assets/Background/b3.png")
     self.playerimages = {
         love.graphics.newImage("assets/player1.png"),
@@ -30,6 +34,8 @@ function NetClientState:init()
     }
     self.powerupimage = love.graphics.newImage("assets/powersupplier.png")
     self.bulletimage  = love.graphics.newImage("assets/Bullet 5x5.png")
+    self.bombimage    = love.graphics.newImage("assets/Bomb_12x12.png")
+    self.laserimage   = love.graphics.newImage("assets/laser.jpg")
     self.font         = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 22)
     self.font2        = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 48)
 
@@ -54,6 +60,9 @@ function NetClientState:update(dt)
                         self.playerData  = msg.players
                         self.bulletData  = msg.bullets
                         self.powerupData = msg.powerups
+                        self.laserData   = msg.lasers
+                        self.bombData    = msg.bombs
+                        self.scatterData = msg.scattershots
                         if msg.gameOver and not self.gameOver then
                             self.gameOver = true
                             self.winnerId = msg.winnerId
@@ -79,6 +88,10 @@ function NetClientState:update(dt)
     end
 
     -- (Game-over is now handled immediately via MSG_GAMEOVER → newScore transition)
+
+    -- Advance bomb warning-circle flash timer (mirrors PlayState.display)
+    self.display = self.display + dt
+    if self.display > 3 then self.display = 0 end
 
     -- 3) Send our input to the host every frame (~60 Hz)
     self.sendTimer = self.sendTimer + dt
@@ -128,7 +141,7 @@ function NetClientState:render()
     end
     love.graphics.setColor(1, 1, 1)
 
-    -- Players (positions received from host)
+    -- Players — mirrors PlayState:render() player draw
     for i, pd in ipairs(self.playerData) do
         if pd.alive then
             local img = self.playerimages[i]
@@ -145,17 +158,41 @@ function NetClientState:render()
         end
     end
 
-    -- Bullets — same image and scale as bullets:render() on the host
+    -- Lasers — mirrors Laser:render()
+    for _, ld in ipairs(self.laserData) do
+        love.graphics.draw(self.laserimage, ld.x1, ld.y1,
+            math.atan2(ld.y2 - ld.y1, ld.x2 - ld.x1), 100, 0.1)
+    end
+
+    -- Bullets — mirrors bullets:render()
     for _, b in ipairs(self.bulletData) do
         love.graphics.draw(self.bulletimage, b.x - 3, b.y - 3, 0, 1.7, 1.7)
     end
 
-    -- Powerup boxes
+    -- Scatter shots — mirrors ScatterShot:render()
+    for _, s in ipairs(self.scatterData) do
+        love.graphics.draw(self.bulletimage, s.x, s.y)
+    end
+
+    -- Bombs — mirrors PlayState bomb block exactly
+    for _, bd in ipairs(self.bombData) do
+        love.graphics.draw(self.bombimage, bd.x - 5, bd.y - 5)
+        if self.display > 3 then
+            love.graphics.circle("line", bd.x, bd.y, 200)
+        end
+        if bd.r > 0 then
+            love.graphics.setColor(255, 165, 0, 0.5)
+            love.graphics.circle("fill", bd.x, bd.y, bd.r)
+        end
+        love.graphics.setColor(1, 1, 1)
+    end
+
+    -- Powerup boxes — mirrors powersuplier:render()
     for _, p in ipairs(self.powerupData) do
         love.graphics.draw(self.powerupimage, p.x - 17, p.y - 19, 0, 0.3, 0.3)
     end
 
-    -- HUD: power name per player
+    -- HUD: pending power name per player
     love.graphics.setFont(self.font)
     for i, pd in ipairs(self.playerData) do
         if pd.pendingpower and pd.pendingpower > 0 then
@@ -169,7 +206,7 @@ function NetClientState:render()
         end
     end
 
-    -- "Waiting" overlay when no state has arrived yet (host is in score screen)
+    -- "Waiting" overlay when host is in the score screen between rounds
     if #self.playerData == 0 and not self.gameOver then
         love.graphics.setColor(0, 0, 0, 0.5)
         love.graphics.rectangle("fill", 0, 0, WINDOW_WIDTH, WINDOW_HEIGHT)
@@ -177,5 +214,4 @@ function NetClientState:render()
         love.graphics.setFont(self.font)
         love.graphics.printf("Waiting for next round…", 0, WINDOW_HEIGHT/2 - 20, WINDOW_WIDTH, "center")
     end
-
 end

--- a/states/PlayState.lua
+++ b/states/PlayState.lua
@@ -336,7 +336,7 @@ function PlayState:update(dt)
             local winnerId = alivePlayers[1]   -- nil if draw
             -- Notify network client of game over (reliable, once)
             if NET.mode == 'host' and NET.peer and not self.hasGameEnded then
-                NET.peer:send(net.encodeGameOver(winnerId or 0), 1, "reliable")
+                NET.peer:send(net.encodeGameOver(winnerId or 0, PLAYER1_SCORE, PLAYER2_SCORE), 1, "reliable")
             end
             self.hasGameEnded = true
             if winnerId then

--- a/states/PlayState.lua
+++ b/states/PlayState.lua
@@ -5,6 +5,7 @@ require 'modules.powerups'
 require 'modules.bullets'
 require 'modules.powersuplier'
 require 'modules.maps'
+local net = require 'modules.net'
 math.randomseed(os.time())
 
 -- Equal-mass elastic collision between two Player objects (shared helper)
@@ -69,16 +70,24 @@ function PlayState:init()
         { x = WINDOW_WIDTH/2,  y = WINDOW_HEIGHT-40  },
     }
 
-    -- Create players; controls come from the live KEY_BINDINGS global
-    -- so any changes made in SettingsState take effect immediately next game
+    -- Create players; in host mode only the host's slot is local
     self.players = {}
     for i = 1, NUM_PLAYERS do
         local sp = spawnPos[i]
         local p  = Player(i, sp.x, sp.y, 30)
-        p.isLocal  = true                    -- both local for now; Phase 3 sets only one
+        if NET.mode == 'host' then
+            p.isLocal = (i == NET.localId)   -- only the host player reads keyboard
+        else
+            p.isLocal = true                 -- local play: all players are local
+        end
         p.controls = KEY_BINDINGS[i] or {}   -- reference to global — live bindings
         self.players[i] = p
     end
+
+    -- Network (host) state
+    self.netTimer           = 0
+    self.lastClientShoot    = false
+    self.lastClientUsepower = false
 
     -- Per-player weapon / power tables (indexed by player ID)
     self.lasers       = {}
@@ -211,6 +220,39 @@ function PlayState:update(dt)
         end
     end
 
+    -- ── Host networking: poll for client input and inject into remote player ──
+    if NET.mode == 'host' and NET.host then
+        local event = NET.host:service(0)
+        while event do
+            if event.type == 'receive' then
+                local msg = net.decode(event.data)
+                if msg and msg.type == net.MSG_INPUT then
+                    local p2 = self.players[2]
+                    if p2 then
+                        p2.networkInput = p2.networkInput or {}
+                        p2.networkInput.rotate = msg.rotate
+                        -- One-shot shoot / usepower (edge-triggered)
+                        if msg.shoot and not self.lastClientShoot then
+                            self.bulletsound:play()
+                            self:shootBullet(2)
+                        end
+                        if msg.usepower and not self.lastClientUsepower
+                                and self.pendingpower[2] > 0 then
+                            self:usePower(2)
+                        end
+                        self.lastClientShoot    = msg.shoot
+                        self.lastClientUsepower = msg.usepower
+                    end
+                end
+            elseif event.type == 'disconnect' then
+                -- Client left; return to title
+                gStateMachine:change('title')
+                return
+            end
+            event = NET.host:service(0)
+        end
+    end
+
     if #alivePlayers > 1 then
         self.timer   = self.timer   + dt
         self.display = self.display + dt
@@ -291,6 +333,11 @@ function PlayState:update(dt)
         if self.statechangetimer > 3 then
             self.blastsound:stop()
             local winnerId = alivePlayers[1]   -- nil if draw
+            -- Notify network client of game over (reliable, once)
+            if NET.mode == 'host' and NET.peer and not self.hasGameEnded then
+                NET.peer:send(net.encodeGameOver(winnerId or 0), 1, "reliable")
+            end
+            self.hasGameEnded = true
             if winnerId then
                 PLAYER_SCORES[winnerId] = (PLAYER_SCORES[winnerId] or 0) + 1
                 -- Keep legacy score globals in sync for the existing score states
@@ -303,6 +350,20 @@ function PlayState:update(dt)
             else
                 gStateMachine:change('newScore', 'player1')   -- draw fallback
             end
+        end
+    end
+
+    -- ── Host networking: broadcast game state to client ───────────────────────
+    if NET.mode == 'host' and NET.peer then
+        self.netTimer = self.netTimer + dt
+        if self.netTimer >= net.TICK_RATE then
+            self.netTimer = 0
+            local gameOver = #alivePlayers <= 1
+            local winnerId = gameOver and (alivePlayers[1] or 0) or 0
+            local stateData = net.encodeState(
+                self.players, self.allBullets, self.Powersuplier,
+                self.pendingpower, gameOver, winnerId)
+            NET.peer:send(stateData, 0, "unreliable")
         end
     end
 end
@@ -342,6 +403,15 @@ function PlayState:exit()
     -- Destroy map colliders
     for _, m in ipairs(self.maps) do
         if m.collider.body then m.collider:destroy() end
+    end
+
+    -- Clean up host-side enet resources after a LAN game
+    if NET.mode == 'host' and NET.host then
+        NET.host:destroy()
+        NET.host    = nil
+        NET.peer    = nil
+        NET.mode    = nil
+        NET.localId = 1
     end
 end
 

--- a/states/PlayState.lua
+++ b/states/PlayState.lua
@@ -88,6 +88,7 @@ function PlayState:init()
     self.netTimer           = 0
     self.lastClientShoot    = false
     self.lastClientUsepower = false
+    self.hasGameEnded       = false   -- guards the one-shot MSG_GAMEOVER send
 
     -- Per-player weapon / power tables (indexed by player ID)
     self.lasers       = {}
@@ -405,14 +406,9 @@ function PlayState:exit()
         if m.collider.body then m.collider:destroy() end
     end
 
-    -- Clean up host-side enet resources after a LAN game
-    if NET.mode == 'host' and NET.host then
-        NET.host:destroy()
-        NET.host    = nil
-        NET.peer    = nil
-        NET.mode    = nil
-        NET.localId = 1
-    end
+    -- NOTE: enet is intentionally NOT destroyed here.
+    -- The connection must survive the newScore→play cycle so the next round
+    -- can start automatically.  TitleState:init() is the single cleanup point.
 end
 
 function PlayState:keypressed(key)

--- a/states/PlayState.lua
+++ b/states/PlayState.lua
@@ -363,7 +363,8 @@ function PlayState:update(dt)
             local winnerId = gameOver and (alivePlayers[1] or 0) or 0
             local stateData = net.encodeState(
                 self.players, self.allBullets, self.Powersuplier,
-                self.pendingpower, gameOver, winnerId)
+                self.pendingpower, gameOver, winnerId,
+                self.lasers, self.bombs, self.scattershots)
             NET.peer:send(stateData, 0, "unreliable")
         end
     end

--- a/states/PlayState.lua
+++ b/states/PlayState.lua
@@ -417,7 +417,8 @@ end
 
 function PlayState:keypressed(key)
     if key == 'escape' then
-        love.event.quit()
+        gStateMachine:change('title')   -- ESC = back to menu (not quit)
+        return
     end
 
     -- Each local player's shoot and usepower keys are driven by their controls table

--- a/states/PlayState.lua
+++ b/states/PlayState.lua
@@ -6,50 +6,21 @@ require 'modules.bullets'
 require 'modules.powersuplier'
 require 'modules.maps'
 local net = require 'modules.net'
+local physics = require 'modules.physics'
 math.randomseed(os.time())
 
--- Equal-mass elastic collision between two Player objects (shared helper)
+-- Thin wrapper around physics.resolveElasticCollision: adapts the Player/collider
+-- API to the pure-Lua function that lives in modules/physics.lua.
 local function resolveElasticCollision(pa, pb)
-    local pax = pa.collider:getX()
-    local pay = pa.collider:getY()
-    local pbx = pb.collider:getX()
-    local pby = pb.collider:getY()
-    local dx   = pbx - pax
-    local dy   = pby - pay
-    local dist = math.sqrt(dx * dx + dy * dy)
-    local minDist = pa.radius + pb.radius
-    if dist >= minDist or dist <= 0 then return end
-
-    local nx = dx / dist
-    local ny = dy / dist
-    local vax = math.cos(pa.angle) * pa.speed
-    local vay = math.sin(pa.angle) * pa.speed
-    local vbx = math.cos(pb.angle) * pb.speed
-    local vby = math.sin(pb.angle) * pb.speed
-    local van = vax * nx + vay * ny
-    local vbn = vbx * nx + vby * ny
-
-    if van - vbn > 0 then   -- only resolve if approaching
-        local r = 0.75
-        local new_van = vbn * r
-        local new_vbn = van * r
-        local new_vax = vax + (new_van - van) * nx
-        local new_vay = vay + (new_van - van) * ny
-        local new_vbx = vbx + (new_vbn - vbn) * nx
-        local new_vby = vby + (new_vbn - vbn) * ny
-        local spda = math.sqrt(new_vax * new_vax + new_vay * new_vay)
-        local spdb = math.sqrt(new_vbx * new_vbx + new_vby * new_vby)
-        local MIN_SPEED, MAX_SPEED = 180, 350
-        pa.speed = math.max(MIN_SPEED, math.min(MAX_SPEED, spda))
-        pb.speed = math.max(MIN_SPEED, math.min(MAX_SPEED, spdb))
-        if spda > 0.1 then pa.angle = math.atan2(new_vay, new_vax) end
-        if spdb > 0.1 then pb.angle = math.atan2(new_vby, new_vbx) end
-    end
-    local overlap = (minDist - dist) / 2 + 1
-    pa.collider:setX(pax - nx * overlap)
-    pa.collider:setY(pay - ny * overlap)
-    pb.collider:setX(pbx + nx * overlap)
-    pb.collider:setY(pby + ny * overlap)
+    local a = { x = pa.collider:getX(), y = pa.collider:getY(),
+                angle = pa.angle, speed = pa.speed, radius = pa.radius }
+    local b = { x = pb.collider:getX(), y = pb.collider:getY(),
+                angle = pb.angle, speed = pb.speed, radius = pb.radius }
+    physics.resolveElasticCollision(a, b)
+    pa.angle, pa.speed = a.angle, a.speed
+    pb.angle, pb.speed = b.angle, b.speed
+    pa.collider:setX(a.x); pa.collider:setY(a.y)
+    pb.collider:setX(b.x); pb.collider:setY(b.y)
 end
 
 function PlayState:init()

--- a/states/RuleBook.lua
+++ b/states/RuleBook.lua
@@ -6,11 +6,15 @@ function RuleBook:init()
 end
 
 function RuleBook:update()
-    if love.keyboard.isDown("return")  then
+    if love.keyboard.isDown("return") then
         gStateMachine:change("play")
     end
+end
 
-
+function RuleBook:keypressed(key)
+    if key == 'escape' then
+        gStateMachine:change('title')
+    end
 end
 
 function RuleBook:render()

--- a/states/TitleState.lua
+++ b/states/TitleState.lua
@@ -1,10 +1,21 @@
 TitleState = Class{__includes = BaseState}
 
 function TitleState:init()
+    -- Single cleanup point for any LAN connection left over from a finished game.
+    -- PlayState intentionally keeps enet alive across rounds; arriving here means
+    -- the player truly exited, so we tear it down now.
+    if NET.host then
+        NET.host:destroy()
+        NET.host    = nil
+        NET.peer    = nil
+        NET.mode    = nil
+        NET.localId = 1
+    end
+
     self.background = love.graphics.newImage("assets/BG.png")
-    self.font = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf",60)
-    self.font2 = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf",30)
-    self.sounds = love.audio.newSource("assets/Sounds/SkyFire (Title Screen).ogg","static")
+    self.font  = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 60)
+    self.font2 = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 30)
+    self.sounds = love.audio.newSource("assets/Sounds/SkyFire (Title Screen).ogg", "static")
     self.sounds:setVolume(0.5)
     self.sounds:setLooping(true)
     self.sounds:play()

--- a/states/TitleState.lua
+++ b/states/TitleState.lua
@@ -23,6 +23,8 @@ end
 function TitleState:keypressed(key)
     if key == 'k' then
         gStateMachine:change("settings")
+    elseif key == 'l' then
+        gStateMachine:change("lobby")
     end
 end
 
@@ -44,5 +46,6 @@ function TitleState:render()
     love.graphics.printf("PRESS ENTER TO PLAY",    0, 480, WINDOW_WIDTH, "center")
     love.graphics.printf("PRESS I FOR RULES",      0, 530, WINDOW_WIDTH, "center")
     love.graphics.printf("PRESS K FOR KEY BINDINGS", 0, 580, WINDOW_WIDTH, "center")
+    love.graphics.printf("PRESS L FOR LAN GAME",     0, 630, WINDOW_WIDTH, "center")
 
 end

--- a/states/TitleState.lua
+++ b/states/TitleState.lua
@@ -25,7 +25,11 @@ function TitleState:keypressed(key)
         gStateMachine:change("settings")
     elseif key == 'l' then
         gStateMachine:change("lobby")
+    elseif key == 'q' then
+        love.event.quit()
     end
+    -- ESC on the title screen does nothing: there is no "previous" screen.
+    -- Fullscreen ESC is already handled globally in main.lua.
 end
 
 function TitleState:exit()
@@ -43,9 +47,13 @@ function TitleState:render()
     love.graphics.setFont(self.font)
     love.graphics.printf("Space Warrior",0,0,WINDOW_WIDTH,"center")
     love.graphics.setFont(self.font2)
-    love.graphics.printf("PRESS ENTER TO PLAY",    0, 480, WINDOW_WIDTH, "center")
-    love.graphics.printf("PRESS I FOR RULES",      0, 530, WINDOW_WIDTH, "center")
-    love.graphics.printf("PRESS K FOR KEY BINDINGS", 0, 580, WINDOW_WIDTH, "center")
-    love.graphics.printf("PRESS L FOR LAN GAME",     0, 630, WINDOW_WIDTH, "center")
+    love.graphics.printf("PRESS ENTER TO PLAY",       0, 460, WINDOW_WIDTH, "center")
+    love.graphics.printf("PRESS I FOR RULES",          0, 505, WINDOW_WIDTH, "center")
+    love.graphics.printf("PRESS K FOR KEY BINDINGS",   0, 550, WINDOW_WIDTH, "center")
+    love.graphics.printf("PRESS L FOR LAN GAME",       0, 595, WINDOW_WIDTH, "center")
+    love.graphics.printf("F11 TOGGLE FULLSCREEN",      0, 640, WINDOW_WIDTH, "center")
+    love.graphics.setColor(1, 0.4, 0.4)
+    love.graphics.printf("PRESS Q TO QUIT",            0, 685, WINDOW_WIDTH, "center")
+    love.graphics.setColor(1, 1, 1)
 
 end

--- a/states/harsh_scoreState.lua
+++ b/states/harsh_scoreState.lua
@@ -69,6 +69,12 @@ function NewScoreState:update(dt)
     end
 end
 
+function NewScoreState:keypressed(key)
+    if key == 'escape' then
+        gStateMachine:change('title')
+    end
+end
+
 function NewScoreState:exit()
     self.sounds:stop()
 end

--- a/states/harsh_scoreState.lua
+++ b/states/harsh_scoreState.lua
@@ -57,7 +57,12 @@ function NewScoreState:update(dt)
         self.player2CurrentPosition = self.player2CurrentPosition - self.animationSpeed * dt / 2
     end
     if self.player1CurrentPosition <= self.player1ProgressMeter.y and self.player2CurrentPosition <= self.player2ProgressMeter.y then
-        gStateMachine:change('play')
+        -- LAN client returns to netclient so the enet connection is reused for the next round
+        if NET.mode == 'client' then
+            gStateMachine:change('netclient')
+        else
+            gStateMachine:change('play')
+        end
     end
 
     if PLAYER1_SCORE == 6 then


### PR DESCRIPTION
## Summary

Adds a minimal busted test harness for pure, non-LOVE modules and wires it into PR CI as a new unit-tests job.

### Changes

- modules/physics.lua — new pure-Lua module. resolveElasticCollision is extracted verbatim from states/PlayState.lua and rewritten to accept plain tables { x, y, angle, speed, radius }. Zero LOVE dependencies. Uses math.atan2 or math.atan so it runs under both LuaJIT (LOVE 11.x) and plain Lua 5.3+.
- states/PlayState.lua — the local resolveElasticCollision becomes a thin wrapper that adapts the Player/collider API to the pure helper. This is the only PlayState change.
- spec/helper.lua — stubs love.data.pack / love.data.unpack using string.pack / string.unpack.
- spec/physics_spec.lua — 6 tests: no-op, same-position, head-on, speed clamping, moving-apart, velocity swap.
- spec/net_spec.lua — 7 tests round-tripping MSG_INPUT, MSG_STATE (empty and fully populated), MSG_START, MSG_GAMEOVER, plus byte-clamp and empty-packet decoding.
- .github/workflows/pr-checks.yml — new unit-tests job: installs lua5.4 + luarocks + busted on Ubuntu and runs 'busted --verbose spec/'.
- .luacheckrc — files["spec"] override pulls in busted's stds and allows the test-side love stub.

### Verification (local)

luacheck: 0 warnings / 0 errors. luac5.4 -p: all pass. busted: 13 successes / 0 failures.

### Scope notes

- Task scope also lists MSG_HELLO round-trips, but MSG_HELLO is not present in modules/net.lua on this branch (LAN-robustness task will introduce it). Left as a follow-up.
- Stacked on top of feature/lan-multiplayer; diff vs main will collapse once LAN merges.
- No new runtime deps. busted is a CI-only dev dep installed via luarocks.