### PR TITLE
feat(ux): add pause state and audio mixer controls

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -31,8 +31,12 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install luacheck
-        run: sudo apt-get update -qq && sudo apt-get install -y luacheck
+      - name: Install Lua 5.4, LuaRocks, and luacheck
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y lua5.4 liblua5.4-dev luarocks
+          sudo update-alternatives --set lua-interpreter /usr/bin/lua5.4
+          sudo luarocks --lua-version=5.4 --lua-dir=/usr install luacheck
 
       - name: Run luacheck
         # .luacheckrc at repo root is picked up automatically

--- a/modules/audio.lua
+++ b/modules/audio.lua
@@ -1,0 +1,84 @@
+local audio = {
+    sources = {},
+    buses = { master = 1, music = 1, sfx = 1 },
+}
+
+local function clamp(value)
+    if type(value) ~= "number" then return 1 end
+    if value < 0 then return 0 end
+    if value > 1 then return 1 end
+    return value
+end
+
+local function syncFromSettings()
+    if type(AUDIO_VOLUMES) ~= "table" then return end
+    audio.buses.master = clamp(AUDIO_VOLUMES.master or 1)
+    audio.buses.music  = clamp(AUDIO_VOLUMES.music or 1)
+    audio.buses.sfx    = clamp(AUDIO_VOLUMES.sfx or 1)
+end
+
+local function effectiveVolume(entry)
+    local busValue = audio.buses[entry.bus] or 1
+    return clamp(entry.baseVolume) * audio.buses.master * busValue
+end
+
+local function applyEntry(entry)
+    if entry.source and entry.source.setVolume then
+        entry.source:setVolume(effectiveVolume(entry))
+    end
+end
+
+function audio.newSource(path, sourceType, bus)
+    syncFromSettings()
+
+    local source = love.audio.newSource(path, sourceType)
+    local entry = {
+        source = source,
+        bus = bus or "sfx",
+        baseVolume = 1,
+    }
+    local wrapper = {}
+
+    function wrapper:setVolume(value)
+        entry.baseVolume = clamp(value)
+        applyEntry(entry)
+    end
+
+    function wrapper:getVolume()
+        return entry.baseVolume
+    end
+
+    setmetatable(wrapper, {
+        __index = function(_, key)
+            local value = entry.source[key]
+            if type(value) == "function" then
+                return function(_, ...)
+                    return value(entry.source, ...)
+                end
+            end
+            return value
+        end,
+    })
+
+    entry.wrapper = wrapper
+    table.insert(audio.sources, entry)
+    applyEntry(entry)
+    return wrapper
+end
+
+function audio.setBus(name, value)
+    if name ~= "master" and name ~= "music" and name ~= "sfx" then return end
+    audio.buses[name] = clamp(value)
+    for _, entry in ipairs(audio.sources) do
+        applyEntry(entry)
+    end
+end
+
+function audio.apply()
+    syncFromSettings()
+    for _, entry in ipairs(audio.sources) do
+        applyEntry(entry)
+    end
+end
+
+return audio

--- a/spec/audio_spec.lua
+++ b/spec/audio_spec.lua
@@ -1,0 +1,80 @@
+require 'spec.helper'
+
+describe('modules.audio', function()
+    local audio
+    local created
+
+    before_each(function()
+        created = {}
+
+        _G.love = _G.love or {}
+        _G.love.audio = {
+            newSource = function(path, sourceType)
+                local source = {
+                    path = path,
+                    sourceType = sourceType,
+                    volume = 1,
+                    looping = false,
+                    playCount = 0,
+                    stopCount = 0,
+                }
+
+                function source:setVolume(value)
+                    self.volume = value
+                end
+
+                function source:getVolume()
+                    return self.volume
+                end
+
+                function source:setLooping(value)
+                    self.looping = value
+                end
+
+                function source:play()
+                    self.playCount = self.playCount + 1
+                end
+
+                function source:stop()
+                    self.stopCount = self.stopCount + 1
+                end
+
+                table.insert(created, source)
+                return source
+            end,
+        }
+
+        _G.AUDIO_VOLUMES = { master = 0.8, music = 0.5, sfx = 0.25 }
+        package.loaded['modules.audio'] = nil
+        audio = require 'modules.audio'
+    end)
+
+    it('applies master and bus volume to new sources', function()
+        local music = audio.newSource('song.ogg', 'static', 'music')
+        music:setVolume(0.5)
+        assert.is_true(math.abs(audio.sources[1].source.volume - 0.2) < 1e-6)
+    end)
+
+    it('updates only the targeted bus when setBus is used', function()
+        local music = audio.newSource('song.ogg', 'static', 'music')
+        local sfx = audio.newSource('shoot.wav', 'static', 'sfx')
+
+        music:setVolume(0.5)
+        sfx:setVolume(1.0)
+        audio.setBus('music', 0.3)
+
+        assert.is_true(math.abs(audio.sources[1].source.volume - 0.12) < 1e-6)
+        assert.is_true(math.abs(audio.sources[2].source.volume - 0.2) < 1e-6)
+    end)
+
+    it('recomputes registered source volumes from AUDIO_VOLUMES on apply', function()
+        local sfx = audio.newSource('shoot.wav', 'static', 'sfx')
+
+        sfx:setVolume(0.4)
+        _G.AUDIO_VOLUMES.master = 0.5
+        _G.AUDIO_VOLUMES.sfx = 0.1
+        audio.apply()
+
+        assert.is_true(math.abs(audio.sources[1].source.volume - 0.02) < 1e-6)
+    end)
+end)

--- a/states/EndState.lua
+++ b/states/EndState.lua
@@ -1,12 +1,14 @@
 EndState = Class{__includes = BaseState}
 
+local audio = require 'modules.audio'
+
 require 'states.PlayState'
 
 function EndState:init()
     self.background = love.graphics.newImage("assets/BG.png")
     self.font = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf",30)
     --self.Animation:startNewTypingAnimation("GAME END",5)
-    self.sounds = love.audio.newSource("assets/Sounds/Victory Tune.ogg","static")
+    self.sounds = audio.newSource("assets/Sounds/Victory Tune.ogg", "static", "music")
     self.sounds:setVolume(0.5)
     self.sounds:setLooping(true)
     self.sounds:play()

--- a/states/PauseState.lua
+++ b/states/PauseState.lua
@@ -1,0 +1,71 @@
+local audio = require 'modules.audio'
+
+local PauseState = Class{__includes = BaseState}
+
+local function freezeWorld(worldObject)
+    if not worldObject then return nil end
+    local originalUpdate = worldObject.update
+    worldObject.update = function() end
+    return originalUpdate
+end
+
+function PauseState:init()
+    self.fontTitle = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 52)
+    self.fontBody  = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 24)
+end
+
+function PauseState:enter(playState)
+    self.playState = playState
+    self.savedWorldUpdate = freezeWorld(world)
+    audio.setBus('music', (AUDIO_VOLUMES.music or 1) * 0.3)
+end
+
+function PauseState:_restore()
+    if self.savedWorldUpdate then
+        world.update = self.savedWorldUpdate
+        self.savedWorldUpdate = nil
+    end
+    audio.apply()
+end
+
+function PauseState:_resume()
+    self:_restore()
+    gStateMachine.current = self.playState
+end
+
+function PauseState:_quitToTitle()
+    self:_restore()
+    gStateMachine.current = self.playState
+    gStateMachine:change('title')
+end
+
+function PauseState:keypressed(key)
+    if key == 'escape' then
+        self:_resume()
+    elseif key == 'q' then
+        self:_quitToTitle()
+    end
+end
+
+function PauseState:exit()
+    self:_restore()
+end
+
+function PauseState:render()
+    self.playState:render()
+
+    love.graphics.setColor(0, 0, 0, 0.65)
+    love.graphics.rectangle('fill', 0, 0, WINDOW_WIDTH, WINDOW_HEIGHT)
+    love.graphics.setColor(0.08, 0.08, 0.12, 0.92)
+    love.graphics.rectangle('fill', WINDOW_WIDTH / 2 - 240, WINDOW_HEIGHT / 2 - 120, 480, 240, 16)
+    love.graphics.setColor(1, 1, 1)
+
+    love.graphics.setFont(self.fontTitle)
+    love.graphics.printf('PAUSED', 0, WINDOW_HEIGHT / 2 - 70, WINDOW_WIDTH, 'center')
+
+    love.graphics.setFont(self.fontBody)
+    love.graphics.printf('ESC — RESUME', 0, WINDOW_HEIGHT / 2 + 5, WINDOW_WIDTH, 'center')
+    love.graphics.printf('Q — QUIT TO TITLE', 0, WINDOW_HEIGHT / 2 + 48, WINDOW_WIDTH, 'center')
+end
+
+return PauseState

--- a/states/PlayState.lua
+++ b/states/PlayState.lua
@@ -392,6 +392,9 @@ function PlayState:keypressed(key)
     end
 
     if key == 'p' then
+        if NET.mode then
+            return
+        end
         local pauseState = PauseState()
         pauseState:enter(self)
         gStateMachine.current = pauseState

--- a/states/PlayState.lua
+++ b/states/PlayState.lua
@@ -7,6 +7,8 @@ require 'modules.powersuplier'
 require 'modules.maps'
 local net = require 'modules.net'
 local physics = require 'modules.physics'
+local audio = require 'modules.audio'
+local PauseState = require 'states.PauseState'
 math.randomseed(os.time())
 
 -- Thin wrapper around physics.resolveElasticCollision: adapts the Player/collider
@@ -105,13 +107,13 @@ function PlayState:init()
         {800, 375,  50, 175}, {850, 325, 175,  50},
     }
 
-    self.sounds = love.audio.newSource("assets/Sounds/Space Heroes.ogg", "static")
+    self.sounds = audio.newSource("assets/Sounds/Space Heroes.ogg", "static", "music")
     self.sounds:setVolume(0.18)
     self.sounds:setLooping(true)
     self.sounds:play()
-    self.blastsound  = love.audio.newSource("assets/Sounds/deathexplosion.mp3", "static")
+    self.blastsound  = audio.newSource("assets/Sounds/deathexplosion.mp3", "static", "sfx")
     self.blastsound:setVolume(0.5)
-    self.bulletsound = love.audio.newSource('assets/Sounds/bulletshootsound.mp3', 'static')
+    self.bulletsound = audio.newSource('assets/Sounds/bulletshootsound.mp3', 'static', 'sfx')
     self.bulletsound:setVolume(0.2)
 end
 
@@ -386,6 +388,13 @@ end
 function PlayState:keypressed(key)
     if key == 'escape' then
         gStateMachine:change('title')   -- ESC = back to menu (not quit)
+        return
+    end
+
+    if key == 'p' then
+        local pauseState = PauseState()
+        pauseState:enter(self)
+        gStateMachine.current = pauseState
         return
     end
 

--- a/states/ScoreState.lua
+++ b/states/ScoreState.lua
@@ -64,6 +64,12 @@ function ScoreState:update(dt)
 
 end
 
+function ScoreState:keypressed(key)
+  if key == 'escape' then
+    gStateMachine:change('title')
+  end
+end
+
 
 
 function ScoreState:render()

--- a/states/SettingsState.lua
+++ b/states/SettingsState.lua
@@ -1,8 +1,12 @@
 SettingsState = Class{__includes = BaseState}
 
+local audio = require 'modules.audio'
+
 -- Action order and their KEY_BINDINGS field names
 local ACTION_LABELS = {"Rotate", "Shoot", "Use Power"}
 local ACTION_KEYS   = {"rotate", "shoot", "usepower"}
+local VOLUME_LABELS = {"Master", "Music", "SFX"}
+local VOLUME_KEYS   = {"master", "music", "sfx"}
 
 -- Per-player display colours (matching the in-game HUD)
 local PLAYER_COLORS = {
@@ -18,10 +22,28 @@ function SettingsState:init()
     self.fontKey    = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 18)
     self.fontFooter = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 14)
     self.background = love.graphics.newImage("assets/BG.png")
+    self.previewMusic = audio.newSource("assets/Sounds/SkyFire (Title Screen).ogg", "static", "music")
+    self.previewMusic:setVolume(0.5)
+    self.previewMusic:setLooping(true)
+    self.previewMusic:play()
 
     self.selectedPlayer = 1     -- 1 .. MAX_PLAYERS
     self.selectedAction = 1     -- 1 = rotate, 2 = shoot, 3 = usepower
+    self.selectedSection = 'bindings'
+    self.selectedAudio = 1
     self.waitingForKey  = false  -- true while listening for a new key press
+end
+
+local function clampVolume(value)
+    if value < 0 then return 0 end
+    if value > 1 then return 1 end
+    return value
+end
+
+function SettingsState:adjustVolume(delta)
+    local key = VOLUME_KEYS[self.selectedAudio]
+    AUDIO_VOLUMES[key] = clampVolume((AUDIO_VOLUMES[key] or 0) + delta)
+    audio.apply()
 end
 
 function SettingsState:keypressed(key)
@@ -40,25 +62,66 @@ function SettingsState:keypressed(key)
         return
     end
 
+    if key == 'escape' then
+        gStateMachine:change('title')
+        return
+    end
+
     -- Navigation
     if key == 'left' then
-        self.selectedPlayer = ((self.selectedPlayer - 2) % MAX_PLAYERS) + 1
+        if self.selectedSection == 'bindings' then
+            self.selectedPlayer = ((self.selectedPlayer - 2) % MAX_PLAYERS) + 1
+        else
+            self:adjustVolume(-0.05)
+        end
     elseif key == 'right' then
-        self.selectedPlayer = (self.selectedPlayer % MAX_PLAYERS) + 1
+        if self.selectedSection == 'bindings' then
+            self.selectedPlayer = (self.selectedPlayer % MAX_PLAYERS) + 1
+        else
+            self:adjustVolume(0.05)
+        end
     elseif key == 'up' then
-        self.selectedAction = ((self.selectedAction - 2) % #ACTION_LABELS) + 1
+        if self.selectedSection == 'bindings' then
+            if self.selectedAction == 1 then
+                self.selectedSection = 'audio'
+                self.selectedAudio = #VOLUME_LABELS
+            else
+                self.selectedAction = self.selectedAction - 1
+            end
+        elseif self.selectedAudio == 1 then
+            self.selectedSection = 'bindings'
+            self.selectedAction = #ACTION_LABELS
+        else
+            self.selectedAudio = self.selectedAudio - 1
+        end
     elseif key == 'down' then
-        self.selectedAction = (self.selectedAction % #ACTION_LABELS) + 1
+        if self.selectedSection == 'bindings' then
+            if self.selectedAction == #ACTION_LABELS then
+                self.selectedSection = 'audio'
+                self.selectedAudio = 1
+            else
+                self.selectedAction = self.selectedAction + 1
+            end
+        elseif self.selectedAudio == #VOLUME_LABELS then
+            self.selectedSection = 'bindings'
+            self.selectedAction = 1
+        else
+            self.selectedAudio = self.selectedAudio + 1
+        end
     elseif key == 'return' or key == ' ' then
-        self.waitingForKey = true
-    elseif key == 'escape' then
-        gStateMachine:change('title')
+        if self.selectedSection == 'bindings' then
+            self.waitingForKey = true
+        elseif settings and settings.save then
+            settings.save()
+        end
     end
 end
 
 function SettingsState:update() end
 function SettingsState:enter() end
-function SettingsState:exit()  end
+function SettingsState:exit()
+    self.previewMusic:stop()
+end
 
 function SettingsState:render()
     -- Background with dark overlay for readability
@@ -71,13 +134,16 @@ function SettingsState:render()
 
     -- Title
     love.graphics.setFont(self.fontTitle)
-    love.graphics.printf("KEY BINDINGS", 0, 28, WINDOW_WIDTH, "center")
+    love.graphics.printf("SETTINGS", 0, 20, WINDOW_WIDTH, "center")
 
     -- Grid layout
     local colW   = WINDOW_WIDTH / MAX_PLAYERS   -- width of each player column
-    local rowH   = 110                           -- height of each action row
-    local gridY  = 120                           -- top of player-header row
-    local cellY0 = gridY + 52                    -- top of first action row
+    local rowH   = 88                            -- height of each action row
+    local gridY  = 96                            -- top of player-header row
+    local cellY0 = gridY + 44                    -- top of first action row
+
+    love.graphics.setFont(self.fontLabel)
+    love.graphics.printf("Key Bindings", 0, 72, WINDOW_WIDTH, "center")
 
     -- Player column headers
     love.graphics.setFont(self.fontLabel)
@@ -94,7 +160,8 @@ function SettingsState:render()
 
         for p = 1, MAX_PLAYERS do
             local cx        = (p-1) * colW
-            local isSelected = (p == self.selectedPlayer and a == self.selectedAction)
+            local isSelected = self.selectedSection == 'bindings'
+                and p == self.selectedPlayer and a == self.selectedAction
             local pc        = PLAYER_COLORS[p]
             local boxX, boxW = cx + 14, colW - 28
             local boxH = 62
@@ -127,17 +194,52 @@ function SettingsState:render()
                 love.graphics.setColor(1, 1, 0.4)
             else
                 keyText = string.upper(KEY_BINDINGS[p][ACTION_KEYS[a]])
-                love.graphics.setColor(isSelected and {1,1,1} or {0.65, 0.65, 0.65})
+                if isSelected then
+                    love.graphics.setColor(1, 1, 1)
+                else
+                    love.graphics.setColor(0.65, 0.65, 0.65)
+                end
             end
             love.graphics.printf(keyText, boxX, cy + 34, boxW, "center")
         end
+    end
+
+    love.graphics.setFont(self.fontLabel)
+    love.graphics.setColor(1, 1, 1)
+    love.graphics.printf("Audio", 0, 430, WINDOW_WIDTH, "center")
+
+    local sliderX = 360
+    local sliderW = 360
+    local sliderH = 18
+    local sliderY = 480
+    local rowGap = 48
+    for i = 1, #VOLUME_LABELS do
+        local y = sliderY + (i - 1) * rowGap
+        local value = AUDIO_VOLUMES[VOLUME_KEYS[i]] or 0
+        local isSelected = self.selectedSection == 'audio' and self.selectedAudio == i
+
+        if isSelected then
+            love.graphics.setColor(1, 1, 1)
+            love.graphics.rectangle('line', sliderX - 12, y - 10, sliderW + 110, sliderH + 20, 8)
+        end
+
+        love.graphics.setColor(0.75, 0.75, 0.75)
+        love.graphics.printf(VOLUME_LABELS[i], 180, y - 4, 150, 'left')
+        love.graphics.setColor(0.2, 0.2, 0.2, 0.9)
+        love.graphics.rectangle('fill', sliderX, y, sliderW, sliderH, 8)
+        love.graphics.setColor(0.3, 0.9, 1, 0.9)
+        love.graphics.rectangle('fill', sliderX, y, sliderW * value, sliderH, 8)
+        love.graphics.setColor(1, 1, 1)
+        love.graphics.rectangle('line', sliderX, y, sliderW, sliderH, 8)
+        love.graphics.printf(string.format('%d%%', math.floor(value * 100 + 0.5)),
+            sliderX + sliderW + 20, y - 4, 90, 'left')
     end
 
     -- Footer hint
     love.graphics.setFont(self.fontFooter)
     love.graphics.setColor(0.55, 0.55, 0.55)
     love.graphics.printf(
-        "LEFT / RIGHT: player    UP / DOWN: action    ENTER: rebind    ESC: back",
+        "BINDINGS: LEFT/RIGHT player, UP/DOWN action, ENTER rebind    AUDIO: UP/DOWN select, LEFT/RIGHT adjust, ENTER save    ESC: back",
         0, WINDOW_HEIGHT - 36, WINDOW_WIDTH, "center")
     love.graphics.setColor(1, 1, 1)
 end

--- a/states/TitleState.lua
+++ b/states/TitleState.lua
@@ -1,5 +1,7 @@
 TitleState = Class{__includes = BaseState}
 
+local audio = require 'modules.audio'
+
 function TitleState:init()
     -- Single cleanup point for any LAN connection left over from a finished game.
     -- PlayState intentionally keeps enet alive across rounds; arriving here means
@@ -15,7 +17,7 @@ function TitleState:init()
     self.background = love.graphics.newImage("assets/BG.png")
     self.font  = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 60)
     self.font2 = love.graphics.newFont("libraries/Bungee/BungeeSpice-Regular.ttf", 30)
-    self.sounds = love.audio.newSource("assets/Sounds/SkyFire (Title Screen).ogg", "static")
+    self.sounds = audio.newSource("assets/Sounds/SkyFire (Title Screen).ogg", "static", "music")
     self.sounds:setVolume(0.5)
     self.sounds:setLooping(true)
     self.sounds:play()

--- a/states/harsh_scoreState.lua
+++ b/states/harsh_scoreState.lua
@@ -1,4 +1,7 @@
 NewScoreState = Class{__includes = BaseState}
+
+local audio = require 'modules.audio'
+
 function NewScoreState:enter(winner)
     print(winner)
     self.player1ProgressMeter = {}
@@ -37,7 +40,7 @@ function NewScoreState:init()
     self.player1image = love.graphics.newImage("assets/player1.png")
     self.player2image = love.graphics.newImage("assets/player2.png")
     self.tablegraphics = love.graphics.newImage("assets/line.png")
-    self.sounds = love.audio.newSource("assets/Sounds/scorestate.wav","static")
+    self.sounds = audio.newSource("assets/Sounds/scorestate.wav", "static", "music")
     self.sounds:setVolume(0.5)
     self.sounds:setLooping(true)
     self.sounds:play()


### PR DESCRIPTION
## Summary
- add a dedicated pause overlay that freezes play updates and supports resume or quit-to-title
- add a shared audio bus helper and wire existing music/SFX sources through it
- add live master/music/SFX sliders in settings plus focused busted coverage for the audio helper

## Verification
- luacheck .
- find . -name "*.lua" ! -path "*/libraries/*" -exec /opt/homebrew/opt/lua@5.4/bin/luac5.4 -p {} \;
- busted --verbose spec/
- combined Phase 2 verifier approved UX-on-main packaging

## Manual follow-up still pending
- start the game, enter PlayState, press P, and confirm the world freezes and music ducks
- while paused, press ESC and confirm the same PlayState instance resumes
- while paused, press Q and confirm it returns cleanly to title
- open Settings from title, move each audio slider, and confirm live effect
- change bindings plus volumes, quit, relaunch, and confirm persistence